### PR TITLE
Add NodeEncodingStrategies typelias as deprecated

### DIFF
--- a/Sources/XMLCoder/Encoder/XMLEncoder.swift
+++ b/Sources/XMLCoder/Encoder/XMLEncoder.swift
@@ -173,6 +173,9 @@ open class XMLEncoder {
         }
     }
 
+    @available(*, deprecated, renamed: "NodeEncodingStrategy")
+    public typealias NodeEncodingStrategies = NodeEncodingStrategy
+
     /// Set of strategies to use for encoding of nodes.
     public enum NodeEncodingStrategy {
         /// Defer to `Encoder` for choosing an encoding. This is the default strategy.

--- a/XMLCoder.xcodeproj/project.pbxproj
+++ b/XMLCoder.xcodeproj/project.pbxproj
@@ -154,9 +154,9 @@
 				OBJ_26 /* Sample XML */,
 				OBJ_27 /* Products */,
 			);
-			indentWidth = 2;
+			indentWidth = 4;
 			sourceTree = "<group>";
-			tabWidth = 2;
+			tabWidth = 4;
 		};
 		OBJ_7 /* Sources */ = {
 			isa = PBXGroup;


### PR DESCRIPTION
This should prevent a source-breaking change and allows next XMLCoder release only with a minor version bump.