### PR TITLE
Honor .sortedKeys

### DIFF
--- a/.swiftformat
+++ b/.swiftformat
@@ -1,0 +1,5 @@
+--indent 4
+--indentcase false
+--linebreaks lf
+--stripunusedargs closure-only
+--trimwhitespace nonblank-lines

--- a/Package.swift
+++ b/Package.swift
@@ -9,7 +9,8 @@ let package = Package(
         // Products define the executables and libraries produced by a package, and make them visible to other packages.
         .library(
             name: "XMLCoder",
-            targets: ["XMLCoder"]),
+            targets: ["XMLCoder"]
+        ),
     ],
     dependencies: [
         // Dependencies declare other packages that this package depends on.
@@ -20,9 +21,11 @@ let package = Package(
         // Targets can depend on other targets in this package, and on products in packages which this package depends on.
         .target(
             name: "XMLCoder",
-            dependencies: []),
+            dependencies: []
+        ),
         .testTarget(
             name: "XMLCoderTests",
-            dependencies: ["XMLCoder"]),
+            dependencies: ["XMLCoder"]
+        ),
     ]
 )

--- a/Sample XML/RJI/RJI.swift
+++ b/Sample XML/RJI/RJI.swift
@@ -17,7 +17,7 @@ struct RSS: Decodable {
     var channel: Channel
     
     enum CodingKeys: String, CodingKey {
-        case channel = "channel"
+        case channel
         
         case dc = "xmlns:dc"
         case sy = "xmlns:sy"

--- a/Sources/XMLCoder/Decoder/DecodingErrorExtension.swift
+++ b/Sources/XMLCoder/Decoder/DecodingErrorExtension.swift
@@ -23,7 +23,7 @@ internal extension DecodingError {
         let description = "Expected to decode \(expectation) but found \(_typeDescription(of: reality)) instead."
         return .typeMismatch(expectation, Context(codingPath: path, debugDescription: description))
     }
-
+    
     /// Returns a description of the type of `value` appropriate for an error message.
     ///
     /// - parameter value: The value whose type to describe.
@@ -38,12 +38,10 @@ internal extension DecodingError {
             return "a string/data"
         } else if value is [Any] {
             return "an array"
-        } else if value is [String : Any] {
+        } else if value is [String: Any] {
             return "a dictionary"
         } else {
             return "\(type(of: value))"
         }
     }
 }
-
-

--- a/Sources/XMLCoder/Decoder/XMLDecoder.swift
+++ b/Sources/XMLCoder/Decoder/XMLDecoder.swift
@@ -196,7 +196,19 @@ open class XMLDecoder {
     
     /// Contextual user-provided information for use during decoding.
     open var userInfo: [CodingUserInfoKey : Any] = [:]
-    
+
+	/// When an XML Element has both attributes and child elements, the CharData within the element will be keyed with the `characterDataToken`
+	/// - Note The following XML has both attribute data, child elements, and character data:
+	/// ```
+	/// <SomeElement SomeAttribute="value">
+	///    some string value
+	///    <SomeOtherElement>valuevalue</SomeOtherElement>
+	/// </SomeElement>
+	/// ```
+	/// The "some string value" will be keyed on "CharData"
+	open var characterDataToken: String?
+
+
     /// Options set on the top-level encoder to pass down the decoding hierarchy.
     internal struct _Options {
         let dateDecodingStrategy: DateDecodingStrategy
@@ -230,7 +242,7 @@ open class XMLDecoder {
     open func decode<T : Decodable>(_ type: T.Type, from data: Data) throws -> T {
         let topLevel: [String: Any]
         do {
-            topLevel = try _XMLStackParser.parse(with: data)
+			topLevel = try _XMLStackParser.parse(with: data, charDataToken: self.characterDataToken)
         } catch {
             throw DecodingError.dataCorrupted(DecodingError.Context(codingPath: [], debugDescription: "The given data was not valid XML.", underlyingError: error))
         }

--- a/Sources/XMLCoder/Decoder/XMLDecoder.swift
+++ b/Sources/XMLCoder/Decoder/XMLDecoder.swift
@@ -196,20 +196,19 @@ open class XMLDecoder {
     open var keyDecodingStrategy: KeyDecodingStrategy = .useDefaultKeys
     
     /// Contextual user-provided information for use during decoding.
-    open var userInfo: [CodingUserInfoKey : Any] = [:]
-
-	/// When an XML Element has both attributes and child elements, the CharData within the element will be keyed with the `characterDataToken`
-	/// - Note The following XML has both attribute data, child elements, and character data:
-	/// ```
-	/// <SomeElement SomeAttribute="value">
-	///    some string value
-	///    <SomeOtherElement>valuevalue</SomeOtherElement>
-	/// </SomeElement>
-	/// ```
-	/// The "some string value" will be keyed on "CharData"
-	open var characterDataToken: String?
-
-
+    open var userInfo: [CodingUserInfoKey: Any] = [:]
+    
+    /// When an XML Element has both attributes and child elements, the CharData within the element will be keyed with the `characterDataToken`
+    /// - Note The following XML has both attribute data, child elements, and character data:
+    /// ```
+    /// <SomeElement SomeAttribute="value">
+    ///    some string value
+    ///    <SomeOtherElement>valuevalue</SomeOtherElement>
+    /// </SomeElement>
+    /// ```
+    /// The "some string value" will be keyed on "CharData"
+    open var characterDataToken: String?
+    
     /// Options set on the top-level encoder to pass down the decoding hierarchy.
     internal struct _Options {
         let dateDecodingStrategy: DateDecodingStrategy
@@ -245,7 +244,7 @@ open class XMLDecoder {
     open func decode<T: Decodable>(_ type: T.Type, from data: Data) throws -> T {
         let topLevel: [String: Any]
         do {
-			topLevel = try _XMLStackParser.parse(with: data, charDataToken: self.characterDataToken)
+            topLevel = try _XMLStackParser.parse(with: data, charDataToken: characterDataToken)
         } catch {
             throw DecodingError.dataCorrupted(DecodingError.Context(codingPath: [], debugDescription: "The given data was not valid XML.", underlyingError: error))
         }

--- a/Sources/XMLCoder/Decoder/XMLDecoder.swift
+++ b/Sources/XMLCoder/Decoder/XMLDecoder.swift
@@ -15,6 +15,7 @@ import Foundation
 /// `XMLDecoder` facilitates the decoding of XML into semantic `Decodable` types.
 open class XMLDecoder {
     // MARK: Options
+    
     /// The strategy to use for decoding `Date` values.
     public enum DateDecodingStrategy {
         /// Defer to `Date` for decoding. This is the default strategy.
@@ -45,7 +46,7 @@ open class XMLDecoder {
                 
                 guard let container = try? decoder.singleValueContainer(),
                     let text = try? container.decode(String.self) else {
-                        throw DecodingError.dataCorrupted(DecodingError.Context(codingPath: decoder.codingPath, debugDescription: "Could not decode date text"))
+                    throw DecodingError.dataCorrupted(DecodingError.Context(codingPath: decoder.codingPath, debugDescription: "Could not decode date text"))
                 }
                 
                 guard let dateFormatter = try formatterForKey(codingKey) else {
@@ -81,7 +82,7 @@ open class XMLDecoder {
                 
                 guard let container = try? decoder.singleValueContainer(),
                     let text = try? container.decode(String.self) else {
-                        throw DecodingError.dataCorrupted(DecodingError.Context(codingPath: decoder.codingPath, debugDescription: "Could not decode date text"))
+                    throw DecodingError.dataCorrupted(DecodingError.Context(codingPath: decoder.codingPath, debugDescription: "Could not decode date text"))
                 }
                 
                 guard let data = try formatterForKey(codingKey) else {
@@ -119,19 +120,19 @@ open class XMLDecoder {
         ///
         /// - Note: Using a key decoding strategy has a nominal performance cost, as each string key has to be inspected for the `_` character.
         case convertFromSnakeCase
-
+        
         /// Convert from "CodingKey" to "codingKey"
         case convertFromCapitalized
-
-        /// Provide a custom conversion from the key in the encoded JSON to the keys specified by the decoded types.
+        
+        /// Provide a custom conversion from the key in the encoded XML to the keys specified by the decoded types.
         /// The full path to the current decoding position is provided for context (in case you need to locate this key within the payload). The returned key is used in place of the last component in the coding path before decoding.
         /// If the result of the conversion is a duplicate key, then only one value will be present in the container for the type to decode from.
         case custom((_ codingPath: [CodingKey]) -> CodingKey)
-
+        
         static func _convertFromCapitalized(_ stringKey: String) -> String {
             guard !stringKey.isEmpty else { return stringKey }
             var result = stringKey
-            let range = result.startIndex...result.index(after: result.startIndex)
+            let range = result.startIndex ... result.index(after: result.startIndex)
             result.replaceSubrange(range, with: result[range].lowercased())
             return result
         }
@@ -151,12 +152,12 @@ open class XMLDecoder {
                 stringKey.formIndex(before: &lastNonUnderscore)
             }
             
-            let keyRange = firstNonUnderscore...lastNonUnderscore
-            let leadingUnderscoreRange = stringKey.startIndex..<firstNonUnderscore
-            let trailingUnderscoreRange = stringKey.index(after: lastNonUnderscore)..<stringKey.endIndex
+            let keyRange = firstNonUnderscore ... lastNonUnderscore
+            let leadingUnderscoreRange = stringKey.startIndex ..< firstNonUnderscore
+            let trailingUnderscoreRange = stringKey.index(after: lastNonUnderscore) ..< stringKey.endIndex
             
             var components = stringKey[keyRange].split(separator: "_")
-            let joinedString : String
+            let joinedString: String
             if components.count == 1 {
                 // No underscores in key, leave the word as is - maybe already camel cased
                 joinedString = String(stringKey[keyRange])
@@ -165,13 +166,13 @@ open class XMLDecoder {
             }
             
             // Do a cheap isEmpty check before creating and appending potentially empty strings
-            let result : String
-            if (leadingUnderscoreRange.isEmpty && trailingUnderscoreRange.isEmpty) {
+            let result: String
+            if leadingUnderscoreRange.isEmpty && trailingUnderscoreRange.isEmpty {
                 result = joinedString
-            } else if (!leadingUnderscoreRange.isEmpty && !trailingUnderscoreRange.isEmpty) {
+            } else if !leadingUnderscoreRange.isEmpty && !trailingUnderscoreRange.isEmpty {
                 // Both leading and trailing underscores
                 result = String(stringKey[leadingUnderscoreRange]) + joinedString + String(stringKey[trailingUnderscoreRange])
-            } else if (!leadingUnderscoreRange.isEmpty) {
+            } else if !leadingUnderscoreRange.isEmpty {
                 // Just leading
                 result = String(stringKey[leadingUnderscoreRange]) + joinedString
             } else {
@@ -215,7 +216,7 @@ open class XMLDecoder {
         let dataDecodingStrategy: DataDecodingStrategy
         let nonConformingFloatDecodingStrategy: NonConformingFloatDecodingStrategy
         let keyDecodingStrategy: KeyDecodingStrategy
-        let userInfo: [CodingUserInfoKey : Any]
+        let userInfo: [CodingUserInfoKey: Any]
     }
     
     /// The options set on the top-level decoder.
@@ -228,10 +229,12 @@ open class XMLDecoder {
     }
     
     // MARK: - Constructing a XML Decoder
+    
     /// Initializes `self` with default strategies.
     public init() {}
     
     // MARK: - Decoding Values
+    
     /// Decodes a top-level value of the given type from the given XML representation.
     ///
     /// - parameter type: The type of the value to decode.
@@ -239,7 +242,7 @@ open class XMLDecoder {
     /// - returns: A value of the requested type.
     /// - throws: `DecodingError.dataCorrupted` if values requested from the payload are corrupted, or if the given data is not valid XML.
     /// - throws: An error if any value throws an error during decoding.
-    open func decode<T : Decodable>(_ type: T.Type, from data: Data) throws -> T {
+    open func decode<T: Decodable>(_ type: T.Type, from data: Data) throws -> T {
         let topLevel: [String: Any]
         do {
 			topLevel = try _XMLStackParser.parse(with: data, charDataToken: self.characterDataToken)
@@ -247,7 +250,7 @@ open class XMLDecoder {
             throw DecodingError.dataCorrupted(DecodingError.Context(codingPath: [], debugDescription: "The given data was not valid XML.", underlyingError: error))
         }
         
-        let decoder = _XMLDecoder(referencing: topLevel, options: self.options)
+        let decoder = _XMLDecoder(referencing: topLevel, options: options)
         
         guard let value = try decoder.unbox(topLevel, as: type) else {
             throw DecodingError.valueNotFound(type, DecodingError.Context(codingPath: [], debugDescription: "The given data did not contain a top-level value."))
@@ -259,7 +262,7 @@ open class XMLDecoder {
 
 // MARK: - _XMLDecoder
 
-internal class _XMLDecoder : Decoder {
+internal class _XMLDecoder: Decoder {
     // MARK: Properties
     
     /// The decoder's storage.
@@ -269,19 +272,19 @@ internal class _XMLDecoder : Decoder {
     internal let options: XMLDecoder._Options
     
     /// The path to the current point in encoding.
-    internal(set) public var codingPath: [CodingKey]
+    public internal(set) var codingPath: [CodingKey]
     
     /// Contextual user-provided information for use during encoding.
-    public var userInfo: [CodingUserInfoKey : Any] {
-        return self.options.userInfo
+    public var userInfo: [CodingUserInfoKey: Any] {
+        return options.userInfo
     }
     
     // MARK: - Initialization
     
     /// Initializes `self` with the given top-level container and options.
     internal init(referencing container: Any, at codingPath: [CodingKey] = [], options: XMLDecoder._Options) {
-        self.storage = _XMLDecodingStorage()
-        self.storage.push(container: container)
+        storage = _XMLDecodingStorage()
+        storage.push(container: container)
         self.codingPath = codingPath
         self.options = options
     }
@@ -289,14 +292,14 @@ internal class _XMLDecoder : Decoder {
     // MARK: - Decoder Methods
     
     public func container<Key>(keyedBy type: Key.Type) throws -> KeyedDecodingContainer<Key> {
-        guard !(self.storage.topContainer is NSNull) else {
+        guard !(storage.topContainer is NSNull) else {
             throw DecodingError.valueNotFound(KeyedDecodingContainer<Key>.self,
-                                              DecodingError.Context(codingPath: self.codingPath,
+                                              DecodingError.Context(codingPath: codingPath,
                                                                     debugDescription: "Cannot get keyed decoding container -- found null value instead."))
         }
         
-        guard let topContainer = self.storage.topContainer as? [String : Any] else {
-            throw DecodingError._typeMismatch(at: self.codingPath, expectation: [String : Any].self, reality: self.storage.topContainer)
+        guard let topContainer = self.storage.topContainer as? [String: Any] else {
+            throw DecodingError._typeMismatch(at: codingPath, expectation: [String: Any].self, reality: storage.topContainer)
         }
         
         let container = _XMLKeyedDecodingContainer<Key>(referencing: self, wrapping: topContainer)
@@ -304,9 +307,9 @@ internal class _XMLDecoder : Decoder {
     }
     
     public func unkeyedContainer() throws -> UnkeyedDecodingContainer {
-        guard !(self.storage.topContainer is NSNull) else {
+        guard !(storage.topContainer is NSNull) else {
             throw DecodingError.valueNotFound(UnkeyedDecodingContainer.self,
-                                              DecodingError.Context(codingPath: self.codingPath,
+                                              DecodingError.Context(codingPath: codingPath,
                                                                     debugDescription: "Cannot get unkeyed decoding container -- found null value instead."))
         }
         
@@ -314,10 +317,10 @@ internal class _XMLDecoder : Decoder {
         
         if let container = self.storage.topContainer as? [Any] {
             topContainer = container
-        } else if let container = self.storage.topContainer as? [AnyHashable: Any]  {
+        } else if let container = self.storage.topContainer as? [AnyHashable: Any] {
             topContainer = [container]
         } else {
-            throw DecodingError._typeMismatch(at: self.codingPath, expectation: [Any].self, reality: self.storage.topContainer)
+            throw DecodingError._typeMismatch(at: codingPath, expectation: [Any].self, reality: storage.topContainer)
         }
         
         return _XMLUnkeyedDecodingContainer(referencing: self, wrapping: topContainer)
@@ -328,93 +331,92 @@ internal class _XMLDecoder : Decoder {
     }
 }
 
-
-extension _XMLDecoder : SingleValueDecodingContainer {
+extension _XMLDecoder: SingleValueDecodingContainer {
     // MARK: SingleValueDecodingContainer Methods
     
     private func expectNonNull<T>(_ type: T.Type) throws {
-        guard !self.decodeNil() else {
-            throw DecodingError.valueNotFound(type, DecodingError.Context(codingPath: self.codingPath, debugDescription: "Expected \(type) but found null value instead."))
+        guard !decodeNil() else {
+            throw DecodingError.valueNotFound(type, DecodingError.Context(codingPath: codingPath, debugDescription: "Expected \(type) but found null value instead."))
         }
     }
     
     public func decodeNil() -> Bool {
-        return self.storage.topContainer is NSNull
+        return storage.topContainer is NSNull
     }
     
     public func decode(_ type: Bool.Type) throws -> Bool {
         try expectNonNull(Bool.self)
-        return try self.unbox(self.storage.topContainer, as: Bool.self)!
+        return try unbox(storage.topContainer, as: Bool.self)!
     }
     
     public func decode(_ type: Int.Type) throws -> Int {
         try expectNonNull(Int.self)
-        return try self.unbox(self.storage.topContainer, as: Int.self)!
+        return try unbox(storage.topContainer, as: Int.self)!
     }
     
     public func decode(_ type: Int8.Type) throws -> Int8 {
         try expectNonNull(Int8.self)
-        return try self.unbox(self.storage.topContainer, as: Int8.self)!
+        return try unbox(storage.topContainer, as: Int8.self)!
     }
     
     public func decode(_ type: Int16.Type) throws -> Int16 {
         try expectNonNull(Int16.self)
-        return try self.unbox(self.storage.topContainer, as: Int16.self)!
+        return try unbox(storage.topContainer, as: Int16.self)!
     }
     
     public func decode(_ type: Int32.Type) throws -> Int32 {
         try expectNonNull(Int32.self)
-        return try self.unbox(self.storage.topContainer, as: Int32.self)!
+        return try unbox(storage.topContainer, as: Int32.self)!
     }
     
     public func decode(_ type: Int64.Type) throws -> Int64 {
         try expectNonNull(Int64.self)
-        return try self.unbox(self.storage.topContainer, as: Int64.self)!
+        return try unbox(storage.topContainer, as: Int64.self)!
     }
     
     public func decode(_ type: UInt.Type) throws -> UInt {
         try expectNonNull(UInt.self)
-        return try self.unbox(self.storage.topContainer, as: UInt.self)!
+        return try unbox(storage.topContainer, as: UInt.self)!
     }
     
     public func decode(_ type: UInt8.Type) throws -> UInt8 {
         try expectNonNull(UInt8.self)
-        return try self.unbox(self.storage.topContainer, as: UInt8.self)!
+        return try unbox(storage.topContainer, as: UInt8.self)!
     }
     
     public func decode(_ type: UInt16.Type) throws -> UInt16 {
         try expectNonNull(UInt16.self)
-        return try self.unbox(self.storage.topContainer, as: UInt16.self)!
+        return try unbox(storage.topContainer, as: UInt16.self)!
     }
     
     public func decode(_ type: UInt32.Type) throws -> UInt32 {
         try expectNonNull(UInt32.self)
-        return try self.unbox(self.storage.topContainer, as: UInt32.self)!
+        return try unbox(storage.topContainer, as: UInt32.self)!
     }
     
     public func decode(_ type: UInt64.Type) throws -> UInt64 {
         try expectNonNull(UInt64.self)
-        return try self.unbox(self.storage.topContainer, as: UInt64.self)!
+        return try unbox(storage.topContainer, as: UInt64.self)!
     }
     
     public func decode(_ type: Float.Type) throws -> Float {
         try expectNonNull(Float.self)
-        return try self.unbox(self.storage.topContainer, as: Float.self)!
+        return try unbox(storage.topContainer, as: Float.self)!
     }
     
     public func decode(_ type: Double.Type) throws -> Double {
         try expectNonNull(Double.self)
-        return try self.unbox(self.storage.topContainer, as: Double.self)!
+        return try unbox(storage.topContainer, as: Double.self)!
     }
     
     public func decode(_ type: String.Type) throws -> String {
         try expectNonNull(String.self)
-        return try self.unbox(self.storage.topContainer, as: String.self)!
+        return try unbox(storage.topContainer, as: String.self)!
     }
     
-    public func decode<T : Decodable>(_ type: T.Type) throws -> T {
+    public func decode<T: Decodable>(_ type: T.Type) throws -> T {
         try expectNonNull(type)
-        return try self.unbox(self.storage.topContainer, as: type)!
+        return try unbox(storage.topContainer, as: type)!
     }
 }
 
@@ -433,7 +435,7 @@ extension _XMLDecoder {
             return false
         }
         
-        throw DecodingError._typeMismatch(at: self.codingPath, expectation: type, reality: value)
+        throw DecodingError._typeMismatch(at: codingPath, expectation: type, reality: value)
     }
     
     internal func unbox(_ value: Any, as type: Int.Type) throws -> Int? {
@@ -442,18 +444,18 @@ extension _XMLDecoder {
         guard let string = value as? String else { return nil }
         
         guard let value = Float(string) else {
-            throw DecodingError._typeMismatch(at: self.codingPath, expectation: type, reality: string)
+            throw DecodingError._typeMismatch(at: codingPath, expectation: type, reality: string)
         }
         
         let number = NSNumber(value: value)
         
         guard number !== kCFBooleanTrue, number !== kCFBooleanFalse else {
-            throw DecodingError._typeMismatch(at: self.codingPath, expectation: type, reality: value)
+            throw DecodingError._typeMismatch(at: codingPath, expectation: type, reality: value)
         }
         
         let int = number.intValue
         guard NSNumber(value: int) == number else {
-            throw DecodingError.dataCorrupted(DecodingError.Context(codingPath: self.codingPath, debugDescription: "Parsed XML number <\(number)> does not fit in \(type)."))
+            throw DecodingError.dataCorrupted(DecodingError.Context(codingPath: codingPath, debugDescription: "Parsed XML number <\(number)> does not fit in \(type)."))
         }
         
         return int
@@ -465,18 +467,18 @@ extension _XMLDecoder {
         guard let string = value as? String else { return nil }
         
         guard let value = Float(string) else {
-            throw DecodingError._typeMismatch(at: self.codingPath, expectation: type, reality: string)
+            throw DecodingError._typeMismatch(at: codingPath, expectation: type, reality: string)
         }
         
         let number = NSNumber(value: value)
         
         guard number !== kCFBooleanTrue, number !== kCFBooleanFalse else {
-            throw DecodingError._typeMismatch(at: self.codingPath, expectation: type, reality: value)
+            throw DecodingError._typeMismatch(at: codingPath, expectation: type, reality: value)
         }
         
         let int8 = number.int8Value
         guard NSNumber(value: int8) == number else {
-            throw DecodingError.dataCorrupted(DecodingError.Context(codingPath: self.codingPath, debugDescription: "Parsed XML number <\(number)> does not fit in \(type)."))
+            throw DecodingError.dataCorrupted(DecodingError.Context(codingPath: codingPath, debugDescription: "Parsed XML number <\(number)> does not fit in \(type)."))
         }
         
         return int8
@@ -488,18 +490,18 @@ extension _XMLDecoder {
         guard let string = value as? String else { return nil }
         
         guard let value = Float(string) else {
-            throw DecodingError._typeMismatch(at: self.codingPath, expectation: type, reality: string)
+            throw DecodingError._typeMismatch(at: codingPath, expectation: type, reality: string)
         }
         
         let number = NSNumber(value: value)
         
         guard number !== kCFBooleanTrue, number !== kCFBooleanFalse else {
-            throw DecodingError._typeMismatch(at: self.codingPath, expectation: type, reality: value)
+            throw DecodingError._typeMismatch(at: codingPath, expectation: type, reality: value)
         }
         
         let int16 = number.int16Value
         guard NSNumber(value: int16) == number else {
-            throw DecodingError.dataCorrupted(DecodingError.Context(codingPath: self.codingPath, debugDescription: "Parsed XML number <\(number)> does not fit in \(type)."))
+            throw DecodingError.dataCorrupted(DecodingError.Context(codingPath: codingPath, debugDescription: "Parsed XML number <\(number)> does not fit in \(type)."))
         }
         
         return int16
@@ -511,18 +513,18 @@ extension _XMLDecoder {
         guard let string = value as? String else { return nil }
         
         guard let value = Float(string) else {
-            throw DecodingError._typeMismatch(at: self.codingPath, expectation: type, reality: string)
+            throw DecodingError._typeMismatch(at: codingPath, expectation: type, reality: string)
         }
         
         let number = NSNumber(value: value)
         
         guard number !== kCFBooleanTrue, number !== kCFBooleanFalse else {
-            throw DecodingError._typeMismatch(at: self.codingPath, expectation: type, reality: value)
+            throw DecodingError._typeMismatch(at: codingPath, expectation: type, reality: value)
         }
         
         let int32 = number.int32Value
         guard NSNumber(value: int32) == number else {
-            throw DecodingError.dataCorrupted(DecodingError.Context(codingPath: self.codingPath, debugDescription: "Parsed XML number <\(number)> does not fit in \(type)."))
+            throw DecodingError.dataCorrupted(DecodingError.Context(codingPath: codingPath, debugDescription: "Parsed XML number <\(number)> does not fit in \(type)."))
         }
         
         return int32
@@ -534,18 +536,18 @@ extension _XMLDecoder {
         guard let string = value as? String else { return nil }
         
         guard let value = Float(string) else {
-            throw DecodingError._typeMismatch(at: self.codingPath, expectation: type, reality: string)
+            throw DecodingError._typeMismatch(at: codingPath, expectation: type, reality: string)
         }
         
         let number = NSNumber(value: value)
         
         guard number !== kCFBooleanTrue, number !== kCFBooleanFalse else {
-            throw DecodingError._typeMismatch(at: self.codingPath, expectation: type, reality: value)
+            throw DecodingError._typeMismatch(at: codingPath, expectation: type, reality: value)
         }
         
         let int64 = number.int64Value
         guard NSNumber(value: int64) == number else {
-            throw DecodingError.dataCorrupted(DecodingError.Context(codingPath: self.codingPath, debugDescription: "Parsed XML number <\(number)> does not fit in \(type)."))
+            throw DecodingError.dataCorrupted(DecodingError.Context(codingPath: codingPath, debugDescription: "Parsed XML number <\(number)> does not fit in \(type)."))
         }
         
         return int64
@@ -557,18 +559,18 @@ extension _XMLDecoder {
         guard let string = value as? String else { return nil }
         
         guard let value = Float(string) else {
-            throw DecodingError._typeMismatch(at: self.codingPath, expectation: type, reality: string)
+            throw DecodingError._typeMismatch(at: codingPath, expectation: type, reality: string)
         }
         
         let number = NSNumber(value: value)
         
         guard number !== kCFBooleanTrue, number !== kCFBooleanFalse else {
-            throw DecodingError._typeMismatch(at: self.codingPath, expectation: type, reality: value)
+            throw DecodingError._typeMismatch(at: codingPath, expectation: type, reality: value)
         }
         
         let uint = number.uintValue
         guard NSNumber(value: uint) == number else {
-            throw DecodingError.dataCorrupted(DecodingError.Context(codingPath: self.codingPath, debugDescription: "Parsed XML number <\(number)> does not fit in \(type)."))
+            throw DecodingError.dataCorrupted(DecodingError.Context(codingPath: codingPath, debugDescription: "Parsed XML number <\(number)> does not fit in \(type)."))
         }
         
         return uint
@@ -580,18 +582,18 @@ extension _XMLDecoder {
         guard let string = value as? String else { return nil }
         
         guard let value = Float(string) else {
-            throw DecodingError._typeMismatch(at: self.codingPath, expectation: type, reality: string)
+            throw DecodingError._typeMismatch(at: codingPath, expectation: type, reality: string)
         }
         
         let number = NSNumber(value: value)
         
         guard number !== kCFBooleanTrue, number !== kCFBooleanFalse else {
-            throw DecodingError._typeMismatch(at: self.codingPath, expectation: type, reality: value)
+            throw DecodingError._typeMismatch(at: codingPath, expectation: type, reality: value)
         }
         
         let uint8 = number.uint8Value
         guard NSNumber(value: uint8) == number else {
-            throw DecodingError.dataCorrupted(DecodingError.Context(codingPath: self.codingPath, debugDescription: "Parsed XML number <\(number)> does not fit in \(type)."))
+            throw DecodingError.dataCorrupted(DecodingError.Context(codingPath: codingPath, debugDescription: "Parsed XML number <\(number)> does not fit in \(type)."))
         }
         
         return uint8
@@ -603,18 +605,18 @@ extension _XMLDecoder {
         guard let string = value as? String else { return nil }
         
         guard let value = Float(string) else {
-            throw DecodingError._typeMismatch(at: self.codingPath, expectation: type, reality: string)
+            throw DecodingError._typeMismatch(at: codingPath, expectation: type, reality: string)
         }
         
         let number = NSNumber(value: value)
         
         guard number !== kCFBooleanTrue, number !== kCFBooleanFalse else {
-            throw DecodingError._typeMismatch(at: self.codingPath, expectation: type, reality: value)
+            throw DecodingError._typeMismatch(at: codingPath, expectation: type, reality: value)
         }
         
         let uint16 = number.uint16Value
         guard NSNumber(value: uint16) == number else {
-            throw DecodingError.dataCorrupted(DecodingError.Context(codingPath: self.codingPath, debugDescription: "Parsed XML number <\(number)> does not fit in \(type)."))
+            throw DecodingError.dataCorrupted(DecodingError.Context(codingPath: codingPath, debugDescription: "Parsed XML number <\(number)> does not fit in \(type)."))
         }
         
         return uint16
@@ -626,18 +628,18 @@ extension _XMLDecoder {
         guard let string = value as? String else { return nil }
         
         guard let value = Float(string) else {
-            throw DecodingError._typeMismatch(at: self.codingPath, expectation: type, reality: string)
+            throw DecodingError._typeMismatch(at: codingPath, expectation: type, reality: string)
         }
         
         let number = NSNumber(value: value)
         
         guard number !== kCFBooleanTrue, number !== kCFBooleanFalse else {
-            throw DecodingError._typeMismatch(at: self.codingPath, expectation: type, reality: value)
+            throw DecodingError._typeMismatch(at: codingPath, expectation: type, reality: value)
         }
         
         let uint32 = number.uint32Value
         guard NSNumber(value: uint32) == number else {
-            throw DecodingError.dataCorrupted(DecodingError.Context(codingPath: self.codingPath, debugDescription: "Parsed XML number <\(number)> does not fit in \(type)."))
+            throw DecodingError.dataCorrupted(DecodingError.Context(codingPath: codingPath, debugDescription: "Parsed XML number <\(number)> does not fit in \(type)."))
         }
         
         return uint32
@@ -649,18 +651,18 @@ extension _XMLDecoder {
         guard let string = value as? String else { return nil }
         
         guard let value = Float(string) else {
-            throw DecodingError._typeMismatch(at: self.codingPath, expectation: type, reality: string)
+            throw DecodingError._typeMismatch(at: codingPath, expectation: type, reality: string)
         }
         
         let number = NSNumber(value: value)
         
         guard number !== kCFBooleanTrue, number !== kCFBooleanFalse else {
-            throw DecodingError._typeMismatch(at: self.codingPath, expectation: type, reality: value)
+            throw DecodingError._typeMismatch(at: codingPath, expectation: type, reality: value)
         }
         
         let uint64 = number.uint64Value
         guard NSNumber(value: uint64) == number else {
-            throw DecodingError.dataCorrupted(DecodingError.Context(codingPath: self.codingPath, debugDescription: "Parsed XML number <\(number)> does not fit in \(type)."))
+            throw DecodingError.dataCorrupted(DecodingError.Context(codingPath: codingPath, debugDescription: "Parsed XML number <\(number)> does not fit in \(type)."))
         }
         
         return uint64
@@ -675,16 +677,16 @@ extension _XMLDecoder {
             let number = NSNumber(value: value)
             
             guard number !== kCFBooleanTrue, number !== kCFBooleanFalse else {
-                throw DecodingError._typeMismatch(at: self.codingPath, expectation: type, reality: value)
+                throw DecodingError._typeMismatch(at: codingPath, expectation: type, reality: value)
             }
             
             let double = number.doubleValue
             guard abs(double) <= Double(Float.greatestFiniteMagnitude) else {
-                throw DecodingError.dataCorrupted(DecodingError.Context(codingPath: self.codingPath, debugDescription: "Parsed XML number \(number) does not fit in \(type)."))
+                throw DecodingError.dataCorrupted(DecodingError.Context(codingPath: codingPath, debugDescription: "Parsed XML number \(number) does not fit in \(type)."))
             }
             
             return Float(double)
-        } else if case let .convertFromString(posInfString, negInfString, nanString) = self.options.nonConformingFloatDecodingStrategy {
+        } else if case let .convertFromString(posInfString, negInfString, nanString) = options.nonConformingFloatDecodingStrategy {
             if string == posInfString {
                 return Float.infinity
             } else if string == negInfString {
@@ -694,7 +696,7 @@ extension _XMLDecoder {
             }
         }
         
-        throw DecodingError._typeMismatch(at: self.codingPath, expectation: type, reality: value)
+        throw DecodingError._typeMismatch(at: codingPath, expectation: type, reality: value)
     }
     
     internal func unbox(_ value: Any, as type: Double.Type) throws -> Double? {
@@ -703,13 +705,12 @@ extension _XMLDecoder {
         guard let string = value as? String else { return nil }
         
         if let number = Decimal(string: string) as NSDecimalNumber? {
-            
             guard number !== kCFBooleanTrue, number !== kCFBooleanFalse else {
-                throw DecodingError._typeMismatch(at: self.codingPath, expectation: type, reality: value)
+                throw DecodingError._typeMismatch(at: codingPath, expectation: type, reality: value)
             }
             
             return number.doubleValue
-        } else if case let .convertFromString(posInfString, negInfString, nanString) = self.options.nonConformingFloatDecodingStrategy {
+        } else if case let .convertFromString(posInfString, negInfString, nanString) = options.nonConformingFloatDecodingStrategy {
             if string == posInfString {
                 return Double.infinity
             } else if string == negInfString {
@@ -719,14 +720,14 @@ extension _XMLDecoder {
             }
         }
         
-        throw DecodingError._typeMismatch(at: self.codingPath, expectation: type, reality: value)
+        throw DecodingError._typeMismatch(at: codingPath, expectation: type, reality: value)
     }
     
     internal func unbox(_ value: Any, as type: String.Type) throws -> String? {
         guard !(value is NSNull) else { return nil }
         
         guard let string = value as? String else {
-            throw DecodingError._typeMismatch(at: self.codingPath, expectation: type, reality: value)
+            throw DecodingError._typeMismatch(at: codingPath, expectation: type, reality: value)
         }
         
         return string
@@ -735,18 +736,18 @@ extension _XMLDecoder {
     internal func unbox(_ value: Any, as type: Date.Type) throws -> Date? {
         guard !(value is NSNull) else { return nil }
         
-        switch self.options.dateDecodingStrategy {
+        switch options.dateDecodingStrategy {
         case .deferredToDate:
-            self.storage.push(container: value)
+            storage.push(container: value)
             defer { self.storage.popContainer() }
             return try Date(from: self)
             
         case .secondsSince1970:
-            let double = try self.unbox(value, as: Double.self)!
+            let double = try unbox(value, as: Double.self)!
             return Date(timeIntervalSince1970: double)
             
         case .millisecondsSince1970:
-            let double = try self.unbox(value, as: Double.self)!
+            let double = try unbox(value, as: Double.self)!
             return Date(timeIntervalSince1970: double / 1000.0)
             
         case .iso8601:
@@ -761,16 +762,16 @@ extension _XMLDecoder {
                 fatalError("ISO8601DateFormatter is unavailable on this platform.")
             }
             
-        case .formatted(let formatter):
-            let string = try self.unbox(value, as: String.self)!
+        case let .formatted(formatter):
+            let string = try unbox(value, as: String.self)!
             guard let date = formatter.date(from: string) else {
-                throw DecodingError.dataCorrupted(DecodingError.Context(codingPath: self.codingPath, debugDescription: "Date string does not match format expected by formatter."))
+                throw DecodingError.dataCorrupted(DecodingError.Context(codingPath: codingPath, debugDescription: "Date string does not match format expected by formatter."))
             }
             
             return date
             
-        case .custom(let closure):
-            self.storage.push(container: value)
+        case let .custom(closure):
+            storage.push(container: value)
             defer { self.storage.popContainer() }
             return try closure(self)
         }
@@ -779,25 +780,25 @@ extension _XMLDecoder {
     internal func unbox(_ value: Any, as type: Data.Type) throws -> Data? {
         guard !(value is NSNull) else { return nil }
         
-        switch self.options.dataDecodingStrategy {
+        switch options.dataDecodingStrategy {
         case .deferredToData:
-            self.storage.push(container: value)
+            storage.push(container: value)
             defer { self.storage.popContainer() }
             return try Data(from: self)
             
         case .base64:
             guard let string = value as? String else {
-                throw DecodingError._typeMismatch(at: self.codingPath, expectation: type, reality: value)
+                throw DecodingError._typeMismatch(at: codingPath, expectation: type, reality: value)
             }
             
             guard let data = Data(base64Encoded: string) else {
-                throw DecodingError.dataCorrupted(DecodingError.Context(codingPath: self.codingPath, debugDescription: "Encountered Data is not valid Base64."))
+                throw DecodingError.dataCorrupted(DecodingError.Context(codingPath: codingPath, debugDescription: "Encountered Data is not valid Base64."))
             }
             
             return data
             
-        case .custom(let closure):
-            self.storage.push(container: value)
+        case let .custom(closure):
+            storage.push(container: value)
             defer { self.storage.popContainer() }
             return try closure(self)
         }
@@ -807,11 +808,11 @@ extension _XMLDecoder {
         guard !(value is NSNull) else { return nil }
         
         // Attempt to bridge from NSDecimalNumber.
-        let doubleValue = try self.unbox(value, as: Double.self)!
+        let doubleValue = try unbox(value, as: Double.self)!
         return Decimal(doubleValue)
     }
     
-    internal func unbox<T : Decodable>(_ value: Any, as type: T.Type) throws -> T? {
+    internal func unbox<T: Decodable>(_ value: Any, as type: T.Type) throws -> T? {
         let decoded: T
         if type == Date.self || type == NSDate.self {
             guard let date = try self.unbox(value, as: Date.self) else { return nil }
@@ -825,7 +826,7 @@ extension _XMLDecoder {
             }
             
             guard let url = URL(string: urlString) else {
-                throw DecodingError.dataCorrupted(DecodingError.Context(codingPath: self.codingPath,
+                throw DecodingError.dataCorrupted(DecodingError.Context(codingPath: codingPath,
                                                                         debugDescription: "Invalid URL string."))
             }
             
@@ -834,7 +835,7 @@ extension _XMLDecoder {
             guard let decimal = try self.unbox(value, as: Decimal.self) else { return nil }
             decoded = decimal as! T
         } else {
-            self.storage.push(container: value)
+            storage.push(container: value)
             defer { self.storage.popContainer() }
             return try type.init(from: self)
         }
@@ -842,4 +843,3 @@ extension _XMLDecoder {
         return decoded
     }
 }
-

--- a/Sources/XMLCoder/Decoder/XMLDecodingStorage.swift
+++ b/Sources/XMLCoder/Decoder/XMLDecodingStorage.swift
@@ -12,34 +12,33 @@ import Foundation
 
 internal struct _XMLDecodingStorage {
     // MARK: Properties
-
+    
     /// The container stack.
     /// Elements may be any one of the XML types (String, [String : Any]).
-    private(set) internal var containers: [Any] = []
-
+    internal private(set) var containers: [Any] = []
+    
     // MARK: - Initialization
-
+    
     /// Initializes `self` with no containers.
     internal init() {}
-
+    
     // MARK: - Modifying the Stack
-
+    
     internal var count: Int {
-        return self.containers.count
+        return containers.count
     }
-
+    
     internal var topContainer: Any {
-        precondition(!self.containers.isEmpty, "Empty container stack.")
-        return self.containers.last!
+        precondition(!containers.isEmpty, "Empty container stack.")
+        return containers.last!
     }
-
+    
     internal mutating func push(container: Any) {
-        self.containers.append(container)
+        containers.append(container)
     }
-
+    
     internal mutating func popContainer() {
-        precondition(!self.containers.isEmpty, "Empty container stack.")
-        self.containers.removeLast()
+        precondition(!containers.isEmpty, "Empty container stack.")
+        containers.removeLast()
     }
 }
-

--- a/Sources/XMLCoder/Decoder/XMLKeyedDecodingContainer.swift
+++ b/Sources/XMLCoder/Decoder/XMLKeyedDecodingContainer.swift
@@ -10,7 +10,7 @@ import Foundation
 
 // MARK: Decoding Containers
 
-internal struct _XMLKeyedDecodingContainer<K : CodingKey> : KeyedDecodingContainerProtocol {
+internal struct _XMLKeyedDecodingContainer<K: CodingKey>: KeyedDecodingContainerProtocol {
     typealias Key = K
     
     // MARK: Properties
@@ -19,15 +19,15 @@ internal struct _XMLKeyedDecodingContainer<K : CodingKey> : KeyedDecodingContain
     private let decoder: _XMLDecoder
     
     /// A reference to the container we're reading from.
-    private let container: [String : Any]
+    private let container: [String: Any]
     
     /// The path of coding keys taken to get to this point in decoding.
-    private(set) public var codingPath: [CodingKey]
+    public private(set) var codingPath: [CodingKey]
     
     // MARK: - Initialization
     
     /// Initializes `self` by referencing the given decoder and container.
-    internal init(referencing decoder: _XMLDecoder, wrapping container: [String : Any]) {
+    internal init(referencing decoder: _XMLDecoder, wrapping container: [String: Any]) {
         self.decoder = decoder
         switch decoder.options.keyDecodingStrategy {
         case .useDefaultKeys:
@@ -37,27 +37,27 @@ internal struct _XMLKeyedDecodingContainer<K : CodingKey> : KeyedDecodingContain
             // If we hit a duplicate key after conversion, then we'll use the first one we saw. Effectively an undefined behavior with dictionaries.
             self.container = Dictionary(container.map {
                 key, value in (XMLDecoder.KeyDecodingStrategy._convertFromSnakeCase(key), value)
-            }, uniquingKeysWith: { (first, _) in first })
+            }, uniquingKeysWith: { first, _ in first })
         case .convertFromCapitalized:
             self.container = Dictionary(container.map {
                 key, value in (XMLDecoder.KeyDecodingStrategy._convertFromCapitalized(key), value)
-            }, uniquingKeysWith: { (first, _) in first })
-        case .custom(let converter):
+            }, uniquingKeysWith: { first, _ in first })
+        case let .custom(converter):
             self.container = Dictionary(container.map {
                 key, value in (converter(decoder.codingPath + [_XMLKey(stringValue: key, intValue: nil)]).stringValue, value)
-            }, uniquingKeysWith: { (first, _) in first })
+            }, uniquingKeysWith: { first, _ in first })
         }
-        self.codingPath = decoder.codingPath
+        codingPath = decoder.codingPath
     }
     
     // MARK: - KeyedDecodingContainerProtocol Methods
     
     public var allKeys: [Key] {
-        return self.container.keys.compactMap { Key(stringValue: $0) }
+        return container.keys.compactMap { Key(stringValue: $0) }
     }
     
     public func contains(_ key: Key) -> Bool {
-        return self.container[key.stringValue] != nil
+        return container[key.stringValue] != nil
     }
     
     private func _errorDescription(of key: CodingKey) -> String {
@@ -87,14 +87,14 @@ internal struct _XMLKeyedDecodingContainer<K : CodingKey> : KeyedDecodingContain
     
     public func decode(_ type: Bool.Type, forKey key: Key) throws -> Bool {
         guard let entry = self.container[key.stringValue] else {
-            throw DecodingError.keyNotFound(key, DecodingError.Context(codingPath: self.decoder.codingPath, debugDescription: "No value associated with key \(_errorDescription(of: key))."))
+            throw DecodingError.keyNotFound(key, DecodingError.Context(codingPath: decoder.codingPath, debugDescription: "No value associated with key \(_errorDescription(of: key))."))
         }
         
-        self.decoder.codingPath.append(key)
+        decoder.codingPath.append(key)
         defer { self.decoder.codingPath.removeLast() }
         
         guard let value = try self.decoder.unbox(entry, as: Bool.self) else {
-            throw DecodingError.valueNotFound(type, DecodingError.Context(codingPath: self.decoder.codingPath, debugDescription: "Expected \(type) value but found null instead."))
+            throw DecodingError.valueNotFound(type, DecodingError.Context(codingPath: decoder.codingPath, debugDescription: "Expected \(type) value but found null instead."))
         }
         
         return value
@@ -102,14 +102,14 @@ internal struct _XMLKeyedDecodingContainer<K : CodingKey> : KeyedDecodingContain
     
     public func decode(_ type: Int.Type, forKey key: Key) throws -> Int {
         guard let entry = self.container[key.stringValue] else {
-            throw DecodingError.keyNotFound(key, DecodingError.Context(codingPath: self.decoder.codingPath, debugDescription: "No value associated with key \(_errorDescription(of: key))."))
+            throw DecodingError.keyNotFound(key, DecodingError.Context(codingPath: decoder.codingPath, debugDescription: "No value associated with key \(_errorDescription(of: key))."))
         }
         
-        self.decoder.codingPath.append(key)
+        decoder.codingPath.append(key)
         defer { self.decoder.codingPath.removeLast() }
         
         guard let value = try self.decoder.unbox(entry, as: Int.self) else {
-            throw DecodingError.valueNotFound(type, DecodingError.Context(codingPath: self.decoder.codingPath, debugDescription: "Expected \(type) value but found null instead."))
+            throw DecodingError.valueNotFound(type, DecodingError.Context(codingPath: decoder.codingPath, debugDescription: "Expected \(type) value but found null instead."))
         }
         
         return value
@@ -117,14 +117,14 @@ internal struct _XMLKeyedDecodingContainer<K : CodingKey> : KeyedDecodingContain
     
     public func decode(_ type: Int8.Type, forKey key: Key) throws -> Int8 {
         guard let entry = self.container[key.stringValue] else {
-            throw DecodingError.keyNotFound(key, DecodingError.Context(codingPath: self.decoder.codingPath, debugDescription: "No value associated with key \(_errorDescription(of: key))."))
+            throw DecodingError.keyNotFound(key, DecodingError.Context(codingPath: decoder.codingPath, debugDescription: "No value associated with key \(_errorDescription(of: key))."))
         }
         
-        self.decoder.codingPath.append(key)
+        decoder.codingPath.append(key)
         defer { self.decoder.codingPath.removeLast() }
         
         guard let value = try self.decoder.unbox(entry, as: Int8.self) else {
-            throw DecodingError.valueNotFound(type, DecodingError.Context(codingPath: self.decoder.codingPath, debugDescription: "Expected \(type) value but found null instead."))
+            throw DecodingError.valueNotFound(type, DecodingError.Context(codingPath: decoder.codingPath, debugDescription: "Expected \(type) value but found null instead."))
         }
         
         return value
@@ -132,14 +132,14 @@ internal struct _XMLKeyedDecodingContainer<K : CodingKey> : KeyedDecodingContain
     
     public func decode(_ type: Int16.Type, forKey key: Key) throws -> Int16 {
         guard let entry = self.container[key.stringValue] else {
-            throw DecodingError.keyNotFound(key, DecodingError.Context(codingPath: self.decoder.codingPath, debugDescription: "No value associated with key \(_errorDescription(of: key))."))
+            throw DecodingError.keyNotFound(key, DecodingError.Context(codingPath: decoder.codingPath, debugDescription: "No value associated with key \(_errorDescription(of: key))."))
         }
         
-        self.decoder.codingPath.append(key)
+        decoder.codingPath.append(key)
         defer { self.decoder.codingPath.removeLast() }
         
         guard let value = try self.decoder.unbox(entry, as: Int16.self) else {
-            throw DecodingError.valueNotFound(type, DecodingError.Context(codingPath: self.decoder.codingPath, debugDescription: "Expected \(type) value but found null instead."))
+            throw DecodingError.valueNotFound(type, DecodingError.Context(codingPath: decoder.codingPath, debugDescription: "Expected \(type) value but found null instead."))
         }
         
         return value
@@ -147,14 +147,14 @@ internal struct _XMLKeyedDecodingContainer<K : CodingKey> : KeyedDecodingContain
     
     public func decode(_ type: Int32.Type, forKey key: Key) throws -> Int32 {
         guard let entry = self.container[key.stringValue] else {
-            throw DecodingError.keyNotFound(key, DecodingError.Context(codingPath: self.decoder.codingPath, debugDescription: "No value associated with key \(_errorDescription(of: key))."))
+            throw DecodingError.keyNotFound(key, DecodingError.Context(codingPath: decoder.codingPath, debugDescription: "No value associated with key \(_errorDescription(of: key))."))
         }
         
-        self.decoder.codingPath.append(key)
+        decoder.codingPath.append(key)
         defer { self.decoder.codingPath.removeLast() }
         
         guard let value = try self.decoder.unbox(entry, as: Int32.self) else {
-            throw DecodingError.valueNotFound(type, DecodingError.Context(codingPath: self.decoder.codingPath, debugDescription: "Expected \(type) value but found null instead."))
+            throw DecodingError.valueNotFound(type, DecodingError.Context(codingPath: decoder.codingPath, debugDescription: "Expected \(type) value but found null instead."))
         }
         
         return value
@@ -162,14 +162,14 @@ internal struct _XMLKeyedDecodingContainer<K : CodingKey> : KeyedDecodingContain
     
     public func decode(_ type: Int64.Type, forKey key: Key) throws -> Int64 {
         guard let entry = self.container[key.stringValue] else {
-            throw DecodingError.keyNotFound(key, DecodingError.Context(codingPath: self.decoder.codingPath, debugDescription: "No value associated with key \(_errorDescription(of: key))."))
+            throw DecodingError.keyNotFound(key, DecodingError.Context(codingPath: decoder.codingPath, debugDescription: "No value associated with key \(_errorDescription(of: key))."))
         }
         
-        self.decoder.codingPath.append(key)
+        decoder.codingPath.append(key)
         defer { self.decoder.codingPath.removeLast() }
         
         guard let value = try self.decoder.unbox(entry, as: Int64.self) else {
-            throw DecodingError.valueNotFound(type, DecodingError.Context(codingPath: self.decoder.codingPath, debugDescription: "Expected \(type) value but found null instead."))
+            throw DecodingError.valueNotFound(type, DecodingError.Context(codingPath: decoder.codingPath, debugDescription: "Expected \(type) value but found null instead."))
         }
         
         return value
@@ -177,14 +177,14 @@ internal struct _XMLKeyedDecodingContainer<K : CodingKey> : KeyedDecodingContain
     
     public func decode(_ type: UInt.Type, forKey key: Key) throws -> UInt {
         guard let entry = self.container[key.stringValue] else {
-            throw DecodingError.keyNotFound(key, DecodingError.Context(codingPath: self.decoder.codingPath, debugDescription: "No value associated with key \(_errorDescription(of: key))."))
+            throw DecodingError.keyNotFound(key, DecodingError.Context(codingPath: decoder.codingPath, debugDescription: "No value associated with key \(_errorDescription(of: key))."))
         }
         
-        self.decoder.codingPath.append(key)
+        decoder.codingPath.append(key)
         defer { self.decoder.codingPath.removeLast() }
         
         guard let value = try self.decoder.unbox(entry, as: UInt.self) else {
-            throw DecodingError.valueNotFound(type, DecodingError.Context(codingPath: self.decoder.codingPath, debugDescription: "Expected \(type) value but found null instead."))
+            throw DecodingError.valueNotFound(type, DecodingError.Context(codingPath: decoder.codingPath, debugDescription: "Expected \(type) value but found null instead."))
         }
         
         return value
@@ -192,14 +192,14 @@ internal struct _XMLKeyedDecodingContainer<K : CodingKey> : KeyedDecodingContain
     
     public func decode(_ type: UInt8.Type, forKey key: Key) throws -> UInt8 {
         guard let entry = self.container[key.stringValue] else {
-            throw DecodingError.keyNotFound(key, DecodingError.Context(codingPath: self.decoder.codingPath, debugDescription: "No value associated with key \(_errorDescription(of: key))."))
+            throw DecodingError.keyNotFound(key, DecodingError.Context(codingPath: decoder.codingPath, debugDescription: "No value associated with key \(_errorDescription(of: key))."))
         }
         
-        self.decoder.codingPath.append(key)
+        decoder.codingPath.append(key)
         defer { self.decoder.codingPath.removeLast() }
         
         guard let value = try self.decoder.unbox(entry, as: UInt8.self) else {
-            throw DecodingError.valueNotFound(type, DecodingError.Context(codingPath: self.decoder.codingPath, debugDescription: "Expected \(type) value but found null instead."))
+            throw DecodingError.valueNotFound(type, DecodingError.Context(codingPath: decoder.codingPath, debugDescription: "Expected \(type) value but found null instead."))
         }
         
         return value
@@ -207,14 +207,14 @@ internal struct _XMLKeyedDecodingContainer<K : CodingKey> : KeyedDecodingContain
     
     public func decode(_ type: UInt16.Type, forKey key: Key) throws -> UInt16 {
         guard let entry = self.container[key.stringValue] else {
-            throw DecodingError.keyNotFound(key, DecodingError.Context(codingPath: self.decoder.codingPath, debugDescription: "No value associated with key \(_errorDescription(of: key))."))
+            throw DecodingError.keyNotFound(key, DecodingError.Context(codingPath: decoder.codingPath, debugDescription: "No value associated with key \(_errorDescription(of: key))."))
         }
         
-        self.decoder.codingPath.append(key)
+        decoder.codingPath.append(key)
         defer { self.decoder.codingPath.removeLast() }
         
         guard let value = try self.decoder.unbox(entry, as: UInt16.self) else {
-            throw DecodingError.valueNotFound(type, DecodingError.Context(codingPath: self.decoder.codingPath, debugDescription: "Expected \(type) value but found null instead."))
+            throw DecodingError.valueNotFound(type, DecodingError.Context(codingPath: decoder.codingPath, debugDescription: "Expected \(type) value but found null instead."))
         }
         
         return value
@@ -222,14 +222,14 @@ internal struct _XMLKeyedDecodingContainer<K : CodingKey> : KeyedDecodingContain
     
     public func decode(_ type: UInt32.Type, forKey key: Key) throws -> UInt32 {
         guard let entry = self.container[key.stringValue] else {
-            throw DecodingError.keyNotFound(key, DecodingError.Context(codingPath: self.decoder.codingPath, debugDescription: "No value associated with key \(_errorDescription(of: key))."))
+            throw DecodingError.keyNotFound(key, DecodingError.Context(codingPath: decoder.codingPath, debugDescription: "No value associated with key \(_errorDescription(of: key))."))
         }
         
-        self.decoder.codingPath.append(key)
+        decoder.codingPath.append(key)
         defer { self.decoder.codingPath.removeLast() }
         
         guard let value = try self.decoder.unbox(entry, as: UInt32.self) else {
-            throw DecodingError.valueNotFound(type, DecodingError.Context(codingPath: self.decoder.codingPath, debugDescription: "Expected \(type) value but found null instead."))
+            throw DecodingError.valueNotFound(type, DecodingError.Context(codingPath: decoder.codingPath, debugDescription: "Expected \(type) value but found null instead."))
         }
         
         return value
@@ -237,14 +237,14 @@ internal struct _XMLKeyedDecodingContainer<K : CodingKey> : KeyedDecodingContain
     
     public func decode(_ type: UInt64.Type, forKey key: Key) throws -> UInt64 {
         guard let entry = self.container[key.stringValue] else {
-            throw DecodingError.keyNotFound(key, DecodingError.Context(codingPath: self.decoder.codingPath, debugDescription: "No value associated with key \(_errorDescription(of: key))."))
+            throw DecodingError.keyNotFound(key, DecodingError.Context(codingPath: decoder.codingPath, debugDescription: "No value associated with key \(_errorDescription(of: key))."))
         }
         
-        self.decoder.codingPath.append(key)
+        decoder.codingPath.append(key)
         defer { self.decoder.codingPath.removeLast() }
         
         guard let value = try self.decoder.unbox(entry, as: UInt64.self) else {
-            throw DecodingError.valueNotFound(type, DecodingError.Context(codingPath: self.decoder.codingPath, debugDescription: "Expected \(type) value but found null instead."))
+            throw DecodingError.valueNotFound(type, DecodingError.Context(codingPath: decoder.codingPath, debugDescription: "Expected \(type) value but found null instead."))
         }
         
         return value
@@ -252,14 +252,14 @@ internal struct _XMLKeyedDecodingContainer<K : CodingKey> : KeyedDecodingContain
     
     public func decode(_ type: Float.Type, forKey key: Key) throws -> Float {
         guard let entry = self.container[key.stringValue] else {
-            throw DecodingError.keyNotFound(key, DecodingError.Context(codingPath: self.decoder.codingPath, debugDescription: "No value associated with key \(_errorDescription(of: key))."))
+            throw DecodingError.keyNotFound(key, DecodingError.Context(codingPath: decoder.codingPath, debugDescription: "No value associated with key \(_errorDescription(of: key))."))
         }
         
-        self.decoder.codingPath.append(key)
+        decoder.codingPath.append(key)
         defer { self.decoder.codingPath.removeLast() }
         
         guard let value = try self.decoder.unbox(entry, as: Float.self) else {
-            throw DecodingError.valueNotFound(type, DecodingError.Context(codingPath: self.decoder.codingPath, debugDescription: "Expected \(type) value but found null instead."))
+            throw DecodingError.valueNotFound(type, DecodingError.Context(codingPath: decoder.codingPath, debugDescription: "Expected \(type) value but found null instead."))
         }
         
         return value
@@ -267,14 +267,14 @@ internal struct _XMLKeyedDecodingContainer<K : CodingKey> : KeyedDecodingContain
     
     public func decode(_ type: Double.Type, forKey key: Key) throws -> Double {
         guard let entry = self.container[key.stringValue] else {
-            throw DecodingError.keyNotFound(key, DecodingError.Context(codingPath: self.decoder.codingPath, debugDescription: "No value associated with key \(_errorDescription(of: key))."))
+            throw DecodingError.keyNotFound(key, DecodingError.Context(codingPath: decoder.codingPath, debugDescription: "No value associated with key \(_errorDescription(of: key))."))
         }
         
-        self.decoder.codingPath.append(key)
+        decoder.codingPath.append(key)
         defer { self.decoder.codingPath.removeLast() }
         
         guard let value = try self.decoder.unbox(entry, as: Double.self) else {
-            throw DecodingError.valueNotFound(type, DecodingError.Context(codingPath: self.decoder.codingPath, debugDescription: "Expected \(type) value but found null instead."))
+            throw DecodingError.valueNotFound(type, DecodingError.Context(codingPath: decoder.codingPath, debugDescription: "Expected \(type) value but found null instead."))
         }
         
         return value
@@ -282,75 +282,75 @@ internal struct _XMLKeyedDecodingContainer<K : CodingKey> : KeyedDecodingContain
     
     public func decode(_ type: String.Type, forKey key: Key) throws -> String {
         guard let entry = self.container[key.stringValue] else {
-            throw DecodingError.keyNotFound(key, DecodingError.Context(codingPath: self.decoder.codingPath, debugDescription: "No value associated with key \(_errorDescription(of: key))."))
+            throw DecodingError.keyNotFound(key, DecodingError.Context(codingPath: decoder.codingPath, debugDescription: "No value associated with key \(_errorDescription(of: key))."))
         }
         
-        self.decoder.codingPath.append(key)
+        decoder.codingPath.append(key)
         defer { self.decoder.codingPath.removeLast() }
         
         guard let value = try self.decoder.unbox(entry, as: String.self) else {
-            throw DecodingError.valueNotFound(type, DecodingError.Context(codingPath: self.decoder.codingPath, debugDescription: "Expected \(type) value but found null instead."))
+            throw DecodingError.valueNotFound(type, DecodingError.Context(codingPath: decoder.codingPath, debugDescription: "Expected \(type) value but found null instead."))
         }
         
         return value
     }
     
-    public func decode<T : Decodable>(_ type: T.Type, forKey key: Key) throws -> T {
+    public func decode<T: Decodable>(_ type: T.Type, forKey key: Key) throws -> T {
         guard let entry = self.container[key.stringValue] else {
-            throw DecodingError.keyNotFound(key, DecodingError.Context(codingPath: self.decoder.codingPath, debugDescription: "No value associated with key \(_errorDescription(of: key))."))
+            throw DecodingError.keyNotFound(key, DecodingError.Context(codingPath: decoder.codingPath, debugDescription: "No value associated with key \(_errorDescription(of: key))."))
         }
         
-        self.decoder.codingPath.append(key)
+        decoder.codingPath.append(key)
         defer { self.decoder.codingPath.removeLast() }
         
         guard let value = try self.decoder.unbox(entry, as: type) else {
-            throw DecodingError.valueNotFound(type, DecodingError.Context(codingPath: self.decoder.codingPath, debugDescription: "Expected \(type) value but found null instead."))
+            throw DecodingError.valueNotFound(type, DecodingError.Context(codingPath: decoder.codingPath, debugDescription: "Expected \(type) value but found null instead."))
         }
         
         return value
     }
     
     public func nestedContainer<NestedKey>(keyedBy type: NestedKey.Type, forKey key: Key) throws -> KeyedDecodingContainer<NestedKey> {
-        self.decoder.codingPath.append(key)
+        decoder.codingPath.append(key)
         defer { self.decoder.codingPath.removeLast() }
         
         guard let value = self.container[key.stringValue] else {
             throw DecodingError.keyNotFound(key,
-                                            DecodingError.Context(codingPath: self.codingPath,
+                                            DecodingError.Context(codingPath: codingPath,
                                                                   debugDescription: "Cannot get \(KeyedDecodingContainer<NestedKey>.self) -- no value found for key \"\(key.stringValue)\""))
         }
         
-        guard let dictionary = value as? [String : Any] else {
-            throw DecodingError._typeMismatch(at: self.codingPath, expectation: [String : Any].self, reality: value)
+        guard let dictionary = value as? [String: Any] else {
+            throw DecodingError._typeMismatch(at: codingPath, expectation: [String: Any].self, reality: value)
         }
         
-        let container = _XMLKeyedDecodingContainer<NestedKey>(referencing: self.decoder, wrapping: dictionary)
+        let container = _XMLKeyedDecodingContainer<NestedKey>(referencing: decoder, wrapping: dictionary)
         return KeyedDecodingContainer(container)
     }
     
     public func nestedUnkeyedContainer(forKey key: Key) throws -> UnkeyedDecodingContainer {
-        self.decoder.codingPath.append(key)
+        decoder.codingPath.append(key)
         defer { self.decoder.codingPath.removeLast() }
         
         guard let value = self.container[key.stringValue] else {
             throw DecodingError.keyNotFound(key,
-                                            DecodingError.Context(codingPath: self.codingPath,
+                                            DecodingError.Context(codingPath: codingPath,
                                                                   debugDescription: "Cannot get UnkeyedDecodingContainer -- no value found for key \"\(key.stringValue)\""))
         }
         
         guard let array = value as? [Any] else {
-            throw DecodingError._typeMismatch(at: self.codingPath, expectation: [Any].self, reality: value)
+            throw DecodingError._typeMismatch(at: codingPath, expectation: [Any].self, reality: value)
         }
         
-        return _XMLUnkeyedDecodingContainer(referencing: self.decoder, wrapping: array)
+        return _XMLUnkeyedDecodingContainer(referencing: decoder, wrapping: array)
     }
     
     private func _superDecoder(forKey key: CodingKey) throws -> Decoder {
-        self.decoder.codingPath.append(key)
+        decoder.codingPath.append(key)
         defer { self.decoder.codingPath.removeLast() }
         
-        let value: Any = self.container[key.stringValue] ?? NSNull()
-        return _XMLDecoder(referencing: value, at: self.decoder.codingPath, options: self.decoder.options)
+        let value: Any = container[key.stringValue] ?? NSNull()
+        return _XMLDecoder(referencing: value, at: decoder.codingPath, options: decoder.options)
     }
     
     public func superDecoder() throws -> Decoder {

--- a/Sources/XMLCoder/Decoder/XMLUnkeyedDecodingContainer.swift
+++ b/Sources/XMLCoder/Decoder/XMLUnkeyedDecodingContainer.swift
@@ -8,7 +8,7 @@
 
 import Foundation
 
-internal struct _XMLUnkeyedDecodingContainer : UnkeyedDecodingContainer {
+internal struct _XMLUnkeyedDecodingContainer: UnkeyedDecodingContainer {
     // MARK: Properties
     
     /// A reference to the decoder we're reading from.
@@ -18,10 +18,10 @@ internal struct _XMLUnkeyedDecodingContainer : UnkeyedDecodingContainer {
     private let container: [Any]
     
     /// The path of coding keys taken to get to this point in decoding.
-    private(set) public var codingPath: [CodingKey]
+    public private(set) var codingPath: [CodingKey]
     
     /// The index of the element we're about to decode.
-    private(set) public var currentIndex: Int
+    public private(set) var currentIndex: Int
     
     // MARK: - Initialization
     
@@ -29,27 +29,27 @@ internal struct _XMLUnkeyedDecodingContainer : UnkeyedDecodingContainer {
     internal init(referencing decoder: _XMLDecoder, wrapping container: [Any]) {
         self.decoder = decoder
         self.container = container
-        self.codingPath = decoder.codingPath
-        self.currentIndex = 0
+        codingPath = decoder.codingPath
+        currentIndex = 0
     }
     
     // MARK: - UnkeyedDecodingContainer Methods
     
     public var count: Int? {
-        return self.container.count
+        return container.count
     }
     
     public var isAtEnd: Bool {
-        return self.currentIndex >= self.count!
+        return currentIndex >= count!
     }
     
     public mutating func decodeNil() throws -> Bool {
-        guard !self.isAtEnd else {
-            throw DecodingError.valueNotFound(Any?.self, DecodingError.Context(codingPath: self.decoder.codingPath + [_XMLKey(index: self.currentIndex)], debugDescription: "Unkeyed container is at end."))
+        guard !isAtEnd else {
+            throw DecodingError.valueNotFound(Any?.self, DecodingError.Context(codingPath: decoder.codingPath + [_XMLKey(index: self.currentIndex)], debugDescription: "Unkeyed container is at end."))
         }
         
-        if self.container[self.currentIndex] is NSNull {
-            self.currentIndex += 1
+        if container[self.currentIndex] is NSNull {
+            currentIndex += 1
             return true
         } else {
             return false
@@ -57,308 +57,308 @@ internal struct _XMLUnkeyedDecodingContainer : UnkeyedDecodingContainer {
     }
     
     public mutating func decode(_ type: Bool.Type) throws -> Bool {
-        guard !self.isAtEnd else {
-            throw DecodingError.valueNotFound(type, DecodingError.Context(codingPath: self.decoder.codingPath + [_XMLKey(index: self.currentIndex)], debugDescription: "Unkeyed container is at end."))
+        guard !isAtEnd else {
+            throw DecodingError.valueNotFound(type, DecodingError.Context(codingPath: decoder.codingPath + [_XMLKey(index: self.currentIndex)], debugDescription: "Unkeyed container is at end."))
         }
         
-        self.decoder.codingPath.append(_XMLKey(index: self.currentIndex))
+        decoder.codingPath.append(_XMLKey(index: currentIndex))
         defer { self.decoder.codingPath.removeLast() }
         
         guard let decoded = try self.decoder.unbox(self.container[self.currentIndex], as: Bool.self) else {
-            throw DecodingError.valueNotFound(type, DecodingError.Context(codingPath: self.decoder.codingPath + [_XMLKey(index: self.currentIndex)], debugDescription: "Expected \(type) but found null instead."))
+            throw DecodingError.valueNotFound(type, DecodingError.Context(codingPath: decoder.codingPath + [_XMLKey(index: self.currentIndex)], debugDescription: "Expected \(type) but found null instead."))
         }
         
-        self.currentIndex += 1
+        currentIndex += 1
         return decoded
     }
     
     public mutating func decode(_ type: Int.Type) throws -> Int {
-        guard !self.isAtEnd else {
-            throw DecodingError.valueNotFound(type, DecodingError.Context(codingPath: self.decoder.codingPath + [_XMLKey(index: self.currentIndex)], debugDescription: "Unkeyed container is at end."))
+        guard !isAtEnd else {
+            throw DecodingError.valueNotFound(type, DecodingError.Context(codingPath: decoder.codingPath + [_XMLKey(index: self.currentIndex)], debugDescription: "Unkeyed container is at end."))
         }
         
-        self.decoder.codingPath.append(_XMLKey(index: self.currentIndex))
+        decoder.codingPath.append(_XMLKey(index: currentIndex))
         defer { self.decoder.codingPath.removeLast() }
         
         guard let decoded = try self.decoder.unbox(self.container[self.currentIndex], as: Int.self) else {
-            throw DecodingError.valueNotFound(type, DecodingError.Context(codingPath: self.decoder.codingPath + [_XMLKey(index: self.currentIndex)], debugDescription: "Expected \(type) but found null instead."))
+            throw DecodingError.valueNotFound(type, DecodingError.Context(codingPath: decoder.codingPath + [_XMLKey(index: self.currentIndex)], debugDescription: "Expected \(type) but found null instead."))
         }
         
-        self.currentIndex += 1
+        currentIndex += 1
         return decoded
     }
     
     public mutating func decode(_ type: Int8.Type) throws -> Int8 {
-        guard !self.isAtEnd else {
-            throw DecodingError.valueNotFound(type, DecodingError.Context(codingPath: self.decoder.codingPath + [_XMLKey(index: self.currentIndex)], debugDescription: "Unkeyed container is at end."))
+        guard !isAtEnd else {
+            throw DecodingError.valueNotFound(type, DecodingError.Context(codingPath: decoder.codingPath + [_XMLKey(index: self.currentIndex)], debugDescription: "Unkeyed container is at end."))
         }
         
-        self.decoder.codingPath.append(_XMLKey(index: self.currentIndex))
+        decoder.codingPath.append(_XMLKey(index: currentIndex))
         defer { self.decoder.codingPath.removeLast() }
         
         guard let decoded = try self.decoder.unbox(self.container[self.currentIndex], as: Int8.self) else {
-            throw DecodingError.valueNotFound(type, DecodingError.Context(codingPath: self.decoder.codingPath + [_XMLKey(index: self.currentIndex)], debugDescription: "Expected \(type) but found null instead."))
+            throw DecodingError.valueNotFound(type, DecodingError.Context(codingPath: decoder.codingPath + [_XMLKey(index: self.currentIndex)], debugDescription: "Expected \(type) but found null instead."))
         }
         
-        self.currentIndex += 1
+        currentIndex += 1
         return decoded
     }
     
     public mutating func decode(_ type: Int16.Type) throws -> Int16 {
-        guard !self.isAtEnd else {
-            throw DecodingError.valueNotFound(type, DecodingError.Context(codingPath: self.decoder.codingPath + [_XMLKey(index: self.currentIndex)], debugDescription: "Unkeyed container is at end."))
+        guard !isAtEnd else {
+            throw DecodingError.valueNotFound(type, DecodingError.Context(codingPath: decoder.codingPath + [_XMLKey(index: self.currentIndex)], debugDescription: "Unkeyed container is at end."))
         }
         
-        self.decoder.codingPath.append(_XMLKey(index: self.currentIndex))
+        decoder.codingPath.append(_XMLKey(index: currentIndex))
         defer { self.decoder.codingPath.removeLast() }
         
         guard let decoded = try self.decoder.unbox(self.container[self.currentIndex], as: Int16.self) else {
-            throw DecodingError.valueNotFound(type, DecodingError.Context(codingPath: self.decoder.codingPath + [_XMLKey(index: self.currentIndex)], debugDescription: "Expected \(type) but found null instead."))
+            throw DecodingError.valueNotFound(type, DecodingError.Context(codingPath: decoder.codingPath + [_XMLKey(index: self.currentIndex)], debugDescription: "Expected \(type) but found null instead."))
         }
         
-        self.currentIndex += 1
+        currentIndex += 1
         return decoded
     }
     
     public mutating func decode(_ type: Int32.Type) throws -> Int32 {
-        guard !self.isAtEnd else {
-            throw DecodingError.valueNotFound(type, DecodingError.Context(codingPath: self.decoder.codingPath + [_XMLKey(index: self.currentIndex)], debugDescription: "Unkeyed container is at end."))
+        guard !isAtEnd else {
+            throw DecodingError.valueNotFound(type, DecodingError.Context(codingPath: decoder.codingPath + [_XMLKey(index: self.currentIndex)], debugDescription: "Unkeyed container is at end."))
         }
         
-        self.decoder.codingPath.append(_XMLKey(index: self.currentIndex))
+        decoder.codingPath.append(_XMLKey(index: currentIndex))
         defer { self.decoder.codingPath.removeLast() }
         
         guard let decoded = try self.decoder.unbox(self.container[self.currentIndex], as: Int32.self) else {
-            throw DecodingError.valueNotFound(type, DecodingError.Context(codingPath: self.decoder.codingPath + [_XMLKey(index: self.currentIndex)], debugDescription: "Expected \(type) but found null instead."))
+            throw DecodingError.valueNotFound(type, DecodingError.Context(codingPath: decoder.codingPath + [_XMLKey(index: self.currentIndex)], debugDescription: "Expected \(type) but found null instead."))
         }
         
-        self.currentIndex += 1
+        currentIndex += 1
         return decoded
     }
     
     public mutating func decode(_ type: Int64.Type) throws -> Int64 {
-        guard !self.isAtEnd else {
-            throw DecodingError.valueNotFound(type, DecodingError.Context(codingPath: self.decoder.codingPath + [_XMLKey(index: self.currentIndex)], debugDescription: "Unkeyed container is at end."))
+        guard !isAtEnd else {
+            throw DecodingError.valueNotFound(type, DecodingError.Context(codingPath: decoder.codingPath + [_XMLKey(index: self.currentIndex)], debugDescription: "Unkeyed container is at end."))
         }
         
-        self.decoder.codingPath.append(_XMLKey(index: self.currentIndex))
+        decoder.codingPath.append(_XMLKey(index: currentIndex))
         defer { self.decoder.codingPath.removeLast() }
         
         guard let decoded = try self.decoder.unbox(self.container[self.currentIndex], as: Int64.self) else {
-            throw DecodingError.valueNotFound(type, DecodingError.Context(codingPath: self.decoder.codingPath + [_XMLKey(index: self.currentIndex)], debugDescription: "Expected \(type) but found null instead."))
+            throw DecodingError.valueNotFound(type, DecodingError.Context(codingPath: decoder.codingPath + [_XMLKey(index: self.currentIndex)], debugDescription: "Expected \(type) but found null instead."))
         }
         
-        self.currentIndex += 1
+        currentIndex += 1
         return decoded
     }
     
     public mutating func decode(_ type: UInt.Type) throws -> UInt {
-        guard !self.isAtEnd else {
-            throw DecodingError.valueNotFound(type, DecodingError.Context(codingPath: self.decoder.codingPath + [_XMLKey(index: self.currentIndex)], debugDescription: "Unkeyed container is at end."))
+        guard !isAtEnd else {
+            throw DecodingError.valueNotFound(type, DecodingError.Context(codingPath: decoder.codingPath + [_XMLKey(index: self.currentIndex)], debugDescription: "Unkeyed container is at end."))
         }
         
-        self.decoder.codingPath.append(_XMLKey(index: self.currentIndex))
+        decoder.codingPath.append(_XMLKey(index: currentIndex))
         defer { self.decoder.codingPath.removeLast() }
         
         guard let decoded = try self.decoder.unbox(self.container[self.currentIndex], as: UInt.self) else {
-            throw DecodingError.valueNotFound(type, DecodingError.Context(codingPath: self.decoder.codingPath + [_XMLKey(index: self.currentIndex)], debugDescription: "Expected \(type) but found null instead."))
+            throw DecodingError.valueNotFound(type, DecodingError.Context(codingPath: decoder.codingPath + [_XMLKey(index: self.currentIndex)], debugDescription: "Expected \(type) but found null instead."))
         }
         
-        self.currentIndex += 1
+        currentIndex += 1
         return decoded
     }
     
     public mutating func decode(_ type: UInt8.Type) throws -> UInt8 {
-        guard !self.isAtEnd else {
-            throw DecodingError.valueNotFound(type, DecodingError.Context(codingPath: self.decoder.codingPath + [_XMLKey(index: self.currentIndex)], debugDescription: "Unkeyed container is at end."))
+        guard !isAtEnd else {
+            throw DecodingError.valueNotFound(type, DecodingError.Context(codingPath: decoder.codingPath + [_XMLKey(index: self.currentIndex)], debugDescription: "Unkeyed container is at end."))
         }
         
-        self.decoder.codingPath.append(_XMLKey(index: self.currentIndex))
+        decoder.codingPath.append(_XMLKey(index: currentIndex))
         defer { self.decoder.codingPath.removeLast() }
         
         guard let decoded = try self.decoder.unbox(self.container[self.currentIndex], as: UInt8.self) else {
-            throw DecodingError.valueNotFound(type, DecodingError.Context(codingPath: self.decoder.codingPath + [_XMLKey(index: self.currentIndex)], debugDescription: "Expected \(type) but found null instead."))
+            throw DecodingError.valueNotFound(type, DecodingError.Context(codingPath: decoder.codingPath + [_XMLKey(index: self.currentIndex)], debugDescription: "Expected \(type) but found null instead."))
         }
         
-        self.currentIndex += 1
+        currentIndex += 1
         return decoded
     }
     
     public mutating func decode(_ type: UInt16.Type) throws -> UInt16 {
-        guard !self.isAtEnd else {
-            throw DecodingError.valueNotFound(type, DecodingError.Context(codingPath: self.decoder.codingPath + [_XMLKey(index: self.currentIndex)], debugDescription: "Unkeyed container is at end."))
+        guard !isAtEnd else {
+            throw DecodingError.valueNotFound(type, DecodingError.Context(codingPath: decoder.codingPath + [_XMLKey(index: self.currentIndex)], debugDescription: "Unkeyed container is at end."))
         }
         
-        self.decoder.codingPath.append(_XMLKey(index: self.currentIndex))
+        decoder.codingPath.append(_XMLKey(index: currentIndex))
         defer { self.decoder.codingPath.removeLast() }
         
         guard let decoded = try self.decoder.unbox(self.container[self.currentIndex], as: UInt16.self) else {
-            throw DecodingError.valueNotFound(type, DecodingError.Context(codingPath: self.decoder.codingPath + [_XMLKey(index: self.currentIndex)], debugDescription: "Expected \(type) but found null instead."))
+            throw DecodingError.valueNotFound(type, DecodingError.Context(codingPath: decoder.codingPath + [_XMLKey(index: self.currentIndex)], debugDescription: "Expected \(type) but found null instead."))
         }
         
-        self.currentIndex += 1
+        currentIndex += 1
         return decoded
     }
     
     public mutating func decode(_ type: UInt32.Type) throws -> UInt32 {
-        guard !self.isAtEnd else {
-            throw DecodingError.valueNotFound(type, DecodingError.Context(codingPath: self.decoder.codingPath + [_XMLKey(index: self.currentIndex)], debugDescription: "Unkeyed container is at end."))
+        guard !isAtEnd else {
+            throw DecodingError.valueNotFound(type, DecodingError.Context(codingPath: decoder.codingPath + [_XMLKey(index: self.currentIndex)], debugDescription: "Unkeyed container is at end."))
         }
         
-        self.decoder.codingPath.append(_XMLKey(index: self.currentIndex))
+        decoder.codingPath.append(_XMLKey(index: currentIndex))
         defer { self.decoder.codingPath.removeLast() }
         
         guard let decoded = try self.decoder.unbox(self.container[self.currentIndex], as: UInt32.self) else {
-            throw DecodingError.valueNotFound(type, DecodingError.Context(codingPath: self.decoder.codingPath + [_XMLKey(index: self.currentIndex)], debugDescription: "Expected \(type) but found null instead."))
+            throw DecodingError.valueNotFound(type, DecodingError.Context(codingPath: decoder.codingPath + [_XMLKey(index: self.currentIndex)], debugDescription: "Expected \(type) but found null instead."))
         }
         
-        self.currentIndex += 1
+        currentIndex += 1
         return decoded
     }
     
     public mutating func decode(_ type: UInt64.Type) throws -> UInt64 {
-        guard !self.isAtEnd else {
-            throw DecodingError.valueNotFound(type, DecodingError.Context(codingPath: self.decoder.codingPath + [_XMLKey(index: self.currentIndex)], debugDescription: "Unkeyed container is at end."))
+        guard !isAtEnd else {
+            throw DecodingError.valueNotFound(type, DecodingError.Context(codingPath: decoder.codingPath + [_XMLKey(index: self.currentIndex)], debugDescription: "Unkeyed container is at end."))
         }
         
-        self.decoder.codingPath.append(_XMLKey(index: self.currentIndex))
+        decoder.codingPath.append(_XMLKey(index: currentIndex))
         defer { self.decoder.codingPath.removeLast() }
         
         guard let decoded = try self.decoder.unbox(self.container[self.currentIndex], as: UInt64.self) else {
-            throw DecodingError.valueNotFound(type, DecodingError.Context(codingPath: self.decoder.codingPath + [_XMLKey(index: self.currentIndex)], debugDescription: "Expected \(type) but found null instead."))
+            throw DecodingError.valueNotFound(type, DecodingError.Context(codingPath: decoder.codingPath + [_XMLKey(index: self.currentIndex)], debugDescription: "Expected \(type) but found null instead."))
         }
         
-        self.currentIndex += 1
+        currentIndex += 1
         return decoded
     }
     
     public mutating func decode(_ type: Float.Type) throws -> Float {
-        guard !self.isAtEnd else {
-            throw DecodingError.valueNotFound(type, DecodingError.Context(codingPath: self.decoder.codingPath + [_XMLKey(index: self.currentIndex)], debugDescription: "Unkeyed container is at end."))
+        guard !isAtEnd else {
+            throw DecodingError.valueNotFound(type, DecodingError.Context(codingPath: decoder.codingPath + [_XMLKey(index: self.currentIndex)], debugDescription: "Unkeyed container is at end."))
         }
         
-        self.decoder.codingPath.append(_XMLKey(index: self.currentIndex))
+        decoder.codingPath.append(_XMLKey(index: currentIndex))
         defer { self.decoder.codingPath.removeLast() }
         
         guard let decoded = try self.decoder.unbox(self.container[self.currentIndex], as: Float.self) else {
-            throw DecodingError.valueNotFound(type, DecodingError.Context(codingPath: self.decoder.codingPath + [_XMLKey(index: self.currentIndex)], debugDescription: "Expected \(type) but found null instead."))
+            throw DecodingError.valueNotFound(type, DecodingError.Context(codingPath: decoder.codingPath + [_XMLKey(index: self.currentIndex)], debugDescription: "Expected \(type) but found null instead."))
         }
         
-        self.currentIndex += 1
+        currentIndex += 1
         return decoded
     }
     
     public mutating func decode(_ type: Double.Type) throws -> Double {
-        guard !self.isAtEnd else {
-            throw DecodingError.valueNotFound(type, DecodingError.Context(codingPath: self.decoder.codingPath + [_XMLKey(index: self.currentIndex)], debugDescription: "Unkeyed container is at end."))
+        guard !isAtEnd else {
+            throw DecodingError.valueNotFound(type, DecodingError.Context(codingPath: decoder.codingPath + [_XMLKey(index: self.currentIndex)], debugDescription: "Unkeyed container is at end."))
         }
         
-        self.decoder.codingPath.append(_XMLKey(index: self.currentIndex))
+        decoder.codingPath.append(_XMLKey(index: currentIndex))
         defer { self.decoder.codingPath.removeLast() }
         
         guard let decoded = try self.decoder.unbox(self.container[self.currentIndex], as: Double.self) else {
-            throw DecodingError.valueNotFound(type, DecodingError.Context(codingPath: self.decoder.codingPath + [_XMLKey(index: self.currentIndex)], debugDescription: "Expected \(type) but found null instead."))
+            throw DecodingError.valueNotFound(type, DecodingError.Context(codingPath: decoder.codingPath + [_XMLKey(index: self.currentIndex)], debugDescription: "Expected \(type) but found null instead."))
         }
         
-        self.currentIndex += 1
+        currentIndex += 1
         return decoded
     }
     
     public mutating func decode(_ type: String.Type) throws -> String {
-        guard !self.isAtEnd else {
-            throw DecodingError.valueNotFound(type, DecodingError.Context(codingPath: self.decoder.codingPath + [_XMLKey(index: self.currentIndex)], debugDescription: "Unkeyed container is at end."))
+        guard !isAtEnd else {
+            throw DecodingError.valueNotFound(type, DecodingError.Context(codingPath: decoder.codingPath + [_XMLKey(index: self.currentIndex)], debugDescription: "Unkeyed container is at end."))
         }
         
-        self.decoder.codingPath.append(_XMLKey(index: self.currentIndex))
+        decoder.codingPath.append(_XMLKey(index: currentIndex))
         defer { self.decoder.codingPath.removeLast() }
         
         guard let decoded = try self.decoder.unbox(self.container[self.currentIndex], as: String.self) else {
-            throw DecodingError.valueNotFound(type, DecodingError.Context(codingPath: self.decoder.codingPath + [_XMLKey(index: self.currentIndex)], debugDescription: "Expected \(type) but found null instead."))
+            throw DecodingError.valueNotFound(type, DecodingError.Context(codingPath: decoder.codingPath + [_XMLKey(index: self.currentIndex)], debugDescription: "Expected \(type) but found null instead."))
         }
         
-        self.currentIndex += 1
+        currentIndex += 1
         return decoded
     }
     
-    public mutating func decode<T : Decodable>(_ type: T.Type) throws -> T {
-        guard !self.isAtEnd else {
-            throw DecodingError.valueNotFound(type, DecodingError.Context(codingPath: self.decoder.codingPath + [_XMLKey(index: self.currentIndex)], debugDescription: "Unkeyed container is at end."))
+    public mutating func decode<T: Decodable>(_ type: T.Type) throws -> T {
+        guard !isAtEnd else {
+            throw DecodingError.valueNotFound(type, DecodingError.Context(codingPath: decoder.codingPath + [_XMLKey(index: self.currentIndex)], debugDescription: "Unkeyed container is at end."))
         }
         
-        self.decoder.codingPath.append(_XMLKey(index: self.currentIndex))
+        decoder.codingPath.append(_XMLKey(index: currentIndex))
         defer { self.decoder.codingPath.removeLast() }
         
         guard let decoded = try self.decoder.unbox(self.container[self.currentIndex], as: type) else {
-            throw DecodingError.valueNotFound(type, DecodingError.Context(codingPath: self.decoder.codingPath + [_XMLKey(index: self.currentIndex)], debugDescription: "Expected \(type) but found null instead."))
+            throw DecodingError.valueNotFound(type, DecodingError.Context(codingPath: decoder.codingPath + [_XMLKey(index: self.currentIndex)], debugDescription: "Expected \(type) but found null instead."))
         }
         
-        self.currentIndex += 1
+        currentIndex += 1
         return decoded
     }
     
     public mutating func nestedContainer<NestedKey>(keyedBy type: NestedKey.Type) throws -> KeyedDecodingContainer<NestedKey> {
-        self.decoder.codingPath.append(_XMLKey(index: self.currentIndex))
+        decoder.codingPath.append(_XMLKey(index: currentIndex))
         defer { self.decoder.codingPath.removeLast() }
         
-        guard !self.isAtEnd else {
+        guard !isAtEnd else {
             throw DecodingError.valueNotFound(KeyedDecodingContainer<NestedKey>.self,
-                                              DecodingError.Context(codingPath: self.codingPath,
+                                              DecodingError.Context(codingPath: codingPath,
                                                                     debugDescription: "Cannot get nested keyed container -- unkeyed container is at end."))
         }
         
         let value = self.container[self.currentIndex]
         guard !(value is NSNull) else {
             throw DecodingError.valueNotFound(KeyedDecodingContainer<NestedKey>.self,
-                                              DecodingError.Context(codingPath: self.codingPath,
+                                              DecodingError.Context(codingPath: codingPath,
                                                                     debugDescription: "Cannot get keyed decoding container -- found null value instead."))
         }
         
-        guard let dictionary = value as? [String : Any] else {
-            throw DecodingError._typeMismatch(at: self.codingPath, expectation: [String : Any].self, reality: value)
+        guard let dictionary = value as? [String: Any] else {
+            throw DecodingError._typeMismatch(at: codingPath, expectation: [String: Any].self, reality: value)
         }
         
-        self.currentIndex += 1
-        let container = _XMLKeyedDecodingContainer<NestedKey>(referencing: self.decoder, wrapping: dictionary)
+        currentIndex += 1
+        let container = _XMLKeyedDecodingContainer<NestedKey>(referencing: decoder, wrapping: dictionary)
         return KeyedDecodingContainer(container)
     }
     
     public mutating func nestedUnkeyedContainer() throws -> UnkeyedDecodingContainer {
-        self.decoder.codingPath.append(_XMLKey(index: self.currentIndex))
+        decoder.codingPath.append(_XMLKey(index: currentIndex))
         defer { self.decoder.codingPath.removeLast() }
         
-        guard !self.isAtEnd else {
+        guard !isAtEnd else {
             throw DecodingError.valueNotFound(UnkeyedDecodingContainer.self,
-                                              DecodingError.Context(codingPath: self.codingPath,
+                                              DecodingError.Context(codingPath: codingPath,
                                                                     debugDescription: "Cannot get nested keyed container -- unkeyed container is at end."))
         }
         
-        let value = self.container[self.currentIndex]
+        let value = container[self.currentIndex]
         guard !(value is NSNull) else {
             throw DecodingError.valueNotFound(UnkeyedDecodingContainer.self,
-                                              DecodingError.Context(codingPath: self.codingPath,
+                                              DecodingError.Context(codingPath: codingPath,
                                                                     debugDescription: "Cannot get keyed decoding container -- found null value instead."))
         }
         
         guard let array = value as? [Any] else {
-            throw DecodingError._typeMismatch(at: self.codingPath, expectation: [Any].self, reality: value)
+            throw DecodingError._typeMismatch(at: codingPath, expectation: [Any].self, reality: value)
         }
         
-        self.currentIndex += 1
-        return _XMLUnkeyedDecodingContainer(referencing: self.decoder, wrapping: array)
+        currentIndex += 1
+        return _XMLUnkeyedDecodingContainer(referencing: decoder, wrapping: array)
     }
     
     public mutating func superDecoder() throws -> Decoder {
-        self.decoder.codingPath.append(_XMLKey(index: self.currentIndex))
+        decoder.codingPath.append(_XMLKey(index: currentIndex))
         defer { self.decoder.codingPath.removeLast() }
         
-        guard !self.isAtEnd else {
+        guard !isAtEnd else {
             throw DecodingError.valueNotFound(Decoder.self,
-                                              DecodingError.Context(codingPath: self.codingPath,
+                                              DecodingError.Context(codingPath: codingPath,
                                                                     debugDescription: "Cannot get superDecoder() -- unkeyed container is at end."))
         }
         
-        let value = self.container[self.currentIndex]
-        self.currentIndex += 1
-        return _XMLDecoder(referencing: value, at: self.decoder.codingPath, options: self.decoder.options)
+        let value = container[self.currentIndex]
+        currentIndex += 1
+        return _XMLDecoder(referencing: value, at: decoder.codingPath, options: decoder.options)
     }
 }

--- a/Sources/XMLCoder/Encoder/EncodingErrorExtension.swift
+++ b/Sources/XMLCoder/Encoder/EncodingErrorExtension.swift
@@ -18,7 +18,7 @@ internal extension EncodingError {
     /// - parameter value: The value that was invalid to encode.
     /// - parameter path: The path of `CodingKey`s taken to encode this value.
     /// - returns: An `EncodingError` with the appropriate path and debug description.
-    internal static func _invalidFloatingPointValue<T : FloatingPoint>(_ value: T, at codingPath: [CodingKey]) -> EncodingError {
+    internal static func _invalidFloatingPointValue<T: FloatingPoint>(_ value: T, at codingPath: [CodingKey]) -> EncodingError {
         let valueDescription: String
         if value == T.infinity {
             valueDescription = "\(T.self).infinity"

--- a/Sources/XMLCoder/Encoder/XMLEncoder.swift
+++ b/Sources/XMLCoder/Encoder/XMLEncoder.swift
@@ -15,8 +15,9 @@ import Foundation
 /// `XMLEncoder` facilitates the encoding of `Encodable` values into XML.
 open class XMLEncoder {
     // MARK: Options
+    
     /// The formatting of the output XML data.
-    public struct OutputFormatting : OptionSet {
+    public struct OutputFormatting: OptionSet {
         /// The format's default value.
         public let rawValue: UInt
         
@@ -30,14 +31,14 @@ open class XMLEncoder {
         
         /// Produce XML with dictionary keys sorted in lexicographic order.
         @available(macOS 10.13, iOS 11.0, watchOS 4.0, tvOS 11.0, *)
-        public static let sortedKeys    = OutputFormatting(rawValue: 1 << 1)
+        public static let sortedKeys = OutputFormatting(rawValue: 1 << 1)
     }
-
+    
     /// A node's encoding tyoe
     public enum NodeEncoding {
         case attribute
         case element
-
+        
         public static let `default`: NodeEncoding = .element
     }
     
@@ -126,7 +127,7 @@ open class XMLEncoder {
         internal static func _convertToSnakeCase(_ stringKey: String) -> String {
             guard !stringKey.isEmpty else { return stringKey }
             
-            var words : [Range<String.Index>] = []
+            var words: [Range<String.Index>] = []
             // The general idea of this algorithm is to split words on transition from lower to upper case, then on transition of >1 upper case characters to lowercase
             //
             // myProperty -> my_property
@@ -134,15 +135,15 @@ open class XMLEncoder {
             //
             // We assume, per Swift naming conventions, that the first character of the key is lowercase.
             var wordStart = stringKey.startIndex
-            var searchRange = stringKey.index(after: wordStart)..<stringKey.endIndex
+            var searchRange = stringKey.index(after: wordStart) ..< stringKey.endIndex
             
             // Find next uppercase character
             while let upperCaseRange = stringKey.rangeOfCharacter(from: CharacterSet.uppercaseLetters, options: [], range: searchRange) {
-                let untilUpperCase = wordStart..<upperCaseRange.lowerBound
+                let untilUpperCase = wordStart ..< upperCaseRange.lowerBound
                 words.append(untilUpperCase)
                 
                 // Find next lowercase character
-                searchRange = upperCaseRange.lowerBound..<searchRange.upperBound
+                searchRange = upperCaseRange.lowerBound ..< searchRange.upperBound
                 guard let lowerCaseRange = stringKey.rangeOfCharacter(from: CharacterSet.lowercaseLetters, options: [], range: searchRange) else {
                     // There are no more lower case letters. Just end here.
                     wordStart = searchRange.lowerBound
@@ -158,32 +159,32 @@ open class XMLEncoder {
                 } else {
                     // There was a range of >1 capital letters. Turn those into a word, stopping at the capital before the lower case character.
                     let beforeLowerIndex = stringKey.index(before: lowerCaseRange.lowerBound)
-                    words.append(upperCaseRange.lowerBound..<beforeLowerIndex)
+                    words.append(upperCaseRange.lowerBound ..< beforeLowerIndex)
                     
                     // Next word starts at the capital before the lowercase we just found
                     wordStart = beforeLowerIndex
                 }
-                searchRange = lowerCaseRange.upperBound..<searchRange.upperBound
+                searchRange = lowerCaseRange.upperBound ..< searchRange.upperBound
             }
-            words.append(wordStart..<searchRange.upperBound)
-            let result = words.map({ (range) in
-                return stringKey[range].lowercased()
+            words.append(wordStart ..< searchRange.upperBound)
+            let result = words.map({ range in
+                stringKey[range].lowercased()
             }).joined(separator: "_")
             return result
         }
     }
-
+    
     @available(*, deprecated, renamed: "NodeEncodingStrategy")
     public typealias NodeEncodingStrategies = NodeEncodingStrategy
-
+    
     /// Set of strategies to use for encoding of nodes.
     public enum NodeEncodingStrategy {
         /// Defer to `Encoder` for choosing an encoding. This is the default strategy.
         case deferredToEncoder
-
+        
         /// Return a closure computing the desired node encoding for the value by its coding key.
         case custom((Encodable.Type, Encoder) -> ((CodingKey) -> XMLEncoder.NodeEncoding))
-
+        
         internal func nodeEncodings(
             forType codableType: Encodable.Type,
             with encoder: Encoder
@@ -191,7 +192,7 @@ open class XMLEncoder {
             switch self {
             case .deferredToEncoder:
                 return { _ in .default }
-            case .custom(let closure):
+            case let .custom(closure):
                 return closure(codableType, encoder)
             }
         }
@@ -219,7 +220,7 @@ open class XMLEncoder {
     open var stringEncodingStrategy: StringEncodingStrategy = .deferredToString
     
     /// Contextual user-provided information for use during encoding.
-    open var userInfo: [CodingUserInfoKey : Any] = [:]
+    open var userInfo: [CodingUserInfoKey: Any] = [:]
     
     /// Options set on the top-level encoder to pass down the encoding hierarchy.
     internal struct _Options {
@@ -229,7 +230,7 @@ open class XMLEncoder {
         let keyEncodingStrategy: KeyEncodingStrategy
         let nodeEncodingStrategy: NodeEncodingStrategy
         let stringEncodingStrategy: StringEncodingStrategy
-        let userInfo: [CodingUserInfoKey : Any]
+        let userInfo: [CodingUserInfoKey: Any]
     }
     
     /// The options set on the top-level encoder.
@@ -244,10 +245,12 @@ open class XMLEncoder {
     }
     
     // MARK: - Constructing a XML Encoder
+    
     /// Initializes `self` with default strategies.
     public init() {}
     
     // MARK: - Encoding Values
+    
     /// Encodes the given top-level value and returns its XML representation.
     ///
     /// - parameter value: The value to encode.
@@ -255,12 +258,12 @@ open class XMLEncoder {
     /// - returns: A new `Data` value containing the encoded XML data.
     /// - throws: `EncodingError.invalidValue` if a non-conforming floating-point value is encountered during encoding, and the encoding strategy is `.throw`.
     /// - throws: An error if any value throws an error during encoding.
-    open func encode<T : Encodable>(_ value: T, withRootKey rootKey: String, header: XMLHeader? = nil) throws -> Data {
+    open func encode<T: Encodable>(_ value: T, withRootKey rootKey: String, header: XMLHeader? = nil) throws -> Data {
         let encoder = _XMLEncoder(
-            options: self.options,
+            options: options,
             nodeEncodings: []
         )
-        encoder.nodeEncodings.append(self.options.nodeEncodingStrategy.nodeEncodings(forType: T.self, with: encoder))
+        encoder.nodeEncodings.append(options.nodeEncodingStrategy.nodeEncodings(forType: T.self, with: encoder))
         
         guard let topLevel = try encoder.box_(value) else {
             throw EncodingError.invalidValue(value, EncodingError.Context(codingPath: [], debugDescription: "Top-level \(T.self) did not encode any values."))
@@ -277,9 +280,9 @@ open class XMLEncoder {
         guard let element = _XMLElement.createRootElement(rootKey: rootKey, object: topLevel) else {
             throw EncodingError.invalidValue(value, EncodingError.Context(codingPath: [], debugDescription: "Unable to encode the given top-level value to XML."))
         }
-
+        
         let withCDATA = stringEncodingStrategy != .deferredToString
-        return element.toXMLString(with: header, withCDATA: withCDATA, formatting: self.outputFormatting).data(using: .utf8, allowLossyConversion: true)!
+        return element.toXMLString(with: header, withCDATA: withCDATA, formatting: outputFormatting).data(using: .utf8, allowLossyConversion: true)!
     }
 }
 
@@ -294,12 +297,12 @@ internal class _XMLEncoder: Encoder {
     
     /// The path to the current point in encoding.
     public var codingPath: [CodingKey]
-
+    
     public var nodeEncodings: [(CodingKey) -> XMLEncoder.NodeEncoding]
     
     /// Contextual user-provided information for use during encoding.
-    public var userInfo: [CodingUserInfoKey : Any] {
-        return self.options.userInfo
+    public var userInfo: [CodingUserInfoKey: Any] {
+        return options.userInfo
     }
     
     // MARK: - Initialization
@@ -311,7 +314,7 @@ internal class _XMLEncoder: Encoder {
         codingPath: [CodingKey] = []
     ) {
         self.options = options
-        self.storage = _XMLEncodingStorage()
+        storage = _XMLEncodingStorage()
         self.codingPath = codingPath
         self.nodeEncodings = nodeEncodings
     }
@@ -326,16 +329,17 @@ internal class _XMLEncoder: Encoder {
         //
         // This means that anytime something that can request a new container goes onto the stack, we MUST push a key onto the coding path.
         // Things which will not request containers do not need to have the coding path extended for them (but it doesn't matter if it is, because they will not reach here).
-        return self.storage.count == self.codingPath.count
+        return storage.count == codingPath.count
     }
     
     // MARK: - Encoder Methods
+    
     public func container<Key>(keyedBy: Key.Type) -> KeyedEncodingContainer<Key> {
         // If an existing keyed container was already requested, return that one.
         let topContainer: NSMutableDictionary
-        if self.canEncodeNewValue {
+        if canEncodeNewValue {
             // We haven't yet pushed a container at this level; do so here.
-            topContainer = self.storage.pushKeyedContainer()
+            topContainer = storage.pushKeyedContainer()
         } else {
             guard let container = self.storage.containers.last as? NSMutableDictionary else {
                 preconditionFailure("Attempt to push new keyed encoding container when already previously encoded at this path.")
@@ -343,18 +347,17 @@ internal class _XMLEncoder: Encoder {
             
             topContainer = container
         }
-
-
-        let container = _XMLKeyedEncodingContainer<Key>(referencing: self, codingPath: self.codingPath, wrapping: topContainer)
+        
+        let container = _XMLKeyedEncodingContainer<Key>(referencing: self, codingPath: codingPath, wrapping: topContainer)
         return KeyedEncodingContainer(container)
     }
     
     public func unkeyedContainer() -> UnkeyedEncodingContainer {
         // If an existing unkeyed container was already requested, return that one.
         let topContainer: NSMutableArray
-        if self.canEncodeNewValue {
+        if canEncodeNewValue {
             // We haven't yet pushed a container at this level; do so here.
-            topContainer = self.storage.pushUnkeyedContainer()
+            topContainer = storage.pushUnkeyedContainer()
         } else {
             guard let container = self.storage.containers.last as? NSMutableArray else {
                 preconditionFailure("Attempt to push new unkeyed encoding container when already previously encoded at this path.")
@@ -363,7 +366,7 @@ internal class _XMLEncoder: Encoder {
             topContainer = container
         }
         
-        return _XMLUnkeyedEncodingContainer(referencing: self, codingPath: self.codingPath, wrapping: topContainer)
+        return _XMLUnkeyedEncodingContainer(referencing: self, codingPath: codingPath, wrapping: topContainer)
     }
     
     public func singleValueContainer() -> SingleValueEncodingContainer {
@@ -373,7 +376,7 @@ internal class _XMLEncoder: Encoder {
 
 // MARK: - Encoding Containers
 
-fileprivate struct _XMLKeyedEncodingContainer<K : CodingKey> : KeyedEncodingContainerProtocol {
+fileprivate struct _XMLKeyedEncodingContainer<K: CodingKey>: KeyedEncodingContainerProtocol {
     typealias Key = K
     
     // MARK: Properties
@@ -385,7 +388,7 @@ fileprivate struct _XMLKeyedEncodingContainer<K : CodingKey> : KeyedEncodingCont
     private let container: NSMutableDictionary
     
     /// The path of coding keys taken to get to this point in encoding.
-    private(set) public var codingPath: [CodingKey]
+    public private(set) var codingPath: [CodingKey]
     
     // MARK: - Initialization
     
@@ -405,7 +408,7 @@ fileprivate struct _XMLKeyedEncodingContainer<K : CodingKey> : KeyedEncodingCont
         case .convertToSnakeCase:
             let newKeyString = XMLEncoder.KeyEncodingStrategy._convertToSnakeCase(key.stringValue)
             return _XMLKey(stringValue: newKeyString, intValue: key.intValue)
-        case .custom(let converter):
+        case let .custom(converter):
             return converter(codingPath + [key])
         }
     }
@@ -413,11 +416,11 @@ fileprivate struct _XMLKeyedEncodingContainer<K : CodingKey> : KeyedEncodingCont
     // MARK: - KeyedEncodingContainerProtocol Methods
     
     public mutating func encodeNil(forKey key: Key) throws {
-        self.container[_converted(key).stringValue] = NSNull()
+        container[_converted(key).stringValue] = NSNull()
     }
     
     public mutating func encode(_ value: Bool, forKey key: Key) throws {
-        self.encoder.codingPath.append(key)
+        encoder.codingPath.append(key)
         defer { self.encoder.codingPath.removeLast() }
         guard let strategy = self.encoder.nodeEncodings.last else {
             preconditionFailure("Attempt to access node encoding strategy from empty stack.")
@@ -425,19 +428,19 @@ fileprivate struct _XMLKeyedEncodingContainer<K : CodingKey> : KeyedEncodingCont
         switch strategy(key) {
         case .attribute:
             if let attributesContainer = self.container[_XMLElement.attributesKey] as? NSMutableDictionary {
-                attributesContainer[_converted(key).stringValue] = self.encoder.box(value)
+                attributesContainer[_converted(key).stringValue] = encoder.box(value)
             } else {
                 let attributesContainer = NSMutableDictionary()
-                attributesContainer[_converted(key).stringValue] = self.encoder.box(value)
-                self.container[_XMLElement.attributesKey] = attributesContainer
+                attributesContainer[_converted(key).stringValue] = encoder.box(value)
+                container[_XMLElement.attributesKey] = attributesContainer
             }
         case .element:
-            self.container[_converted(key).stringValue] = self.encoder.box(value)
+            container[_converted(key).stringValue] = encoder.box(value)
         }
     }
     
     public mutating func encode(_ value: Int, forKey key: Key) throws {
-        self.encoder.codingPath.append(key)
+        encoder.codingPath.append(key)
         defer { self.encoder.codingPath.removeLast() }
         guard let strategy = self.encoder.nodeEncodings.last else {
             preconditionFailure("Attempt to access node encoding strategy from empty stack.")
@@ -445,19 +448,19 @@ fileprivate struct _XMLKeyedEncodingContainer<K : CodingKey> : KeyedEncodingCont
         switch strategy(key) {
         case .attribute:
             if let attributesContainer = self.container[_XMLElement.attributesKey] as? NSMutableDictionary {
-                attributesContainer[_converted(key).stringValue] = self.encoder.box(value)
+                attributesContainer[_converted(key).stringValue] = encoder.box(value)
             } else {
                 let attributesContainer = NSMutableDictionary()
-                attributesContainer[_converted(key).stringValue] = self.encoder.box(value)
-                self.container[_XMLElement.attributesKey] = attributesContainer
+                attributesContainer[_converted(key).stringValue] = encoder.box(value)
+                container[_XMLElement.attributesKey] = attributesContainer
             }
         case .element:
-            self.container[_converted(key).stringValue] = self.encoder.box(value)
+            container[_converted(key).stringValue] = encoder.box(value)
         }
     }
     
     public mutating func encode(_ value: Int8, forKey key: Key) throws {
-        self.encoder.codingPath.append(key)
+        encoder.codingPath.append(key)
         defer { self.encoder.codingPath.removeLast() }
         guard let strategy = self.encoder.nodeEncodings.last else {
             preconditionFailure("Attempt to access node encoding strategy from empty stack.")
@@ -465,19 +468,19 @@ fileprivate struct _XMLKeyedEncodingContainer<K : CodingKey> : KeyedEncodingCont
         switch strategy(key) {
         case .attribute:
             if let attributesContainer = self.container[_XMLElement.attributesKey] as? NSMutableDictionary {
-                attributesContainer[_converted(key).stringValue] = self.encoder.box(value)
+                attributesContainer[_converted(key).stringValue] = encoder.box(value)
             } else {
                 let attributesContainer = NSMutableDictionary()
-                attributesContainer[_converted(key).stringValue] = self.encoder.box(value)
-                self.container[_XMLElement.attributesKey] = attributesContainer
+                attributesContainer[_converted(key).stringValue] = encoder.box(value)
+                container[_XMLElement.attributesKey] = attributesContainer
             }
         case .element:
-            self.container[_converted(key).stringValue] = self.encoder.box(value)
+            container[_converted(key).stringValue] = encoder.box(value)
         }
     }
     
     public mutating func encode(_ value: Int16, forKey key: Key) throws {
-        self.encoder.codingPath.append(key)
+        encoder.codingPath.append(key)
         defer { self.encoder.codingPath.removeLast() }
         guard let strategy = self.encoder.nodeEncodings.last else {
             preconditionFailure("Attempt to access node encoding strategy from empty stack.")
@@ -485,19 +488,19 @@ fileprivate struct _XMLKeyedEncodingContainer<K : CodingKey> : KeyedEncodingCont
         switch strategy(key) {
         case .attribute:
             if let attributesContainer = self.container[_XMLElement.attributesKey] as? NSMutableDictionary {
-                attributesContainer[_converted(key).stringValue] = self.encoder.box(value)
+                attributesContainer[_converted(key).stringValue] = encoder.box(value)
             } else {
                 let attributesContainer = NSMutableDictionary()
-                attributesContainer[_converted(key).stringValue] = self.encoder.box(value)
-                self.container[_XMLElement.attributesKey] = attributesContainer
+                attributesContainer[_converted(key).stringValue] = encoder.box(value)
+                container[_XMLElement.attributesKey] = attributesContainer
             }
         case .element:
-            self.container[_converted(key).stringValue] = self.encoder.box(value)
+            container[_converted(key).stringValue] = encoder.box(value)
         }
     }
     
     public mutating func encode(_ value: Int32, forKey key: Key) throws {
-        self.encoder.codingPath.append(key)
+        encoder.codingPath.append(key)
         defer { self.encoder.codingPath.removeLast() }
         guard let strategy = self.encoder.nodeEncodings.last else {
             preconditionFailure("Attempt to access node encoding strategy from empty stack.")
@@ -505,19 +508,19 @@ fileprivate struct _XMLKeyedEncodingContainer<K : CodingKey> : KeyedEncodingCont
         switch strategy(key) {
         case .attribute:
             if let attributesContainer = self.container[_XMLElement.attributesKey] as? NSMutableDictionary {
-                attributesContainer[_converted(key).stringValue] = self.encoder.box(value)
+                attributesContainer[_converted(key).stringValue] = encoder.box(value)
             } else {
                 let attributesContainer = NSMutableDictionary()
-                attributesContainer[_converted(key).stringValue] = self.encoder.box(value)
-                self.container[_XMLElement.attributesKey] = attributesContainer
+                attributesContainer[_converted(key).stringValue] = encoder.box(value)
+                container[_XMLElement.attributesKey] = attributesContainer
             }
         case .element:
-            self.container[_converted(key).stringValue] = self.encoder.box(value)
+            container[_converted(key).stringValue] = encoder.box(value)
         }
     }
     
     public mutating func encode(_ value: Int64, forKey key: Key) throws {
-        self.encoder.codingPath.append(key)
+        encoder.codingPath.append(key)
         defer { self.encoder.codingPath.removeLast() }
         guard let strategy = self.encoder.nodeEncodings.last else {
             preconditionFailure("Attempt to access node encoding strategy from empty stack.")
@@ -525,19 +528,19 @@ fileprivate struct _XMLKeyedEncodingContainer<K : CodingKey> : KeyedEncodingCont
         switch strategy(key) {
         case .attribute:
             if let attributesContainer = self.container[_XMLElement.attributesKey] as? NSMutableDictionary {
-                attributesContainer[_converted(key).stringValue] = self.encoder.box(value)
+                attributesContainer[_converted(key).stringValue] = encoder.box(value)
             } else {
                 let attributesContainer = NSMutableDictionary()
-                attributesContainer[_converted(key).stringValue] = self.encoder.box(value)
-                self.container[_XMLElement.attributesKey] = attributesContainer
+                attributesContainer[_converted(key).stringValue] = encoder.box(value)
+                container[_XMLElement.attributesKey] = attributesContainer
             }
         case .element:
-            self.container[_converted(key).stringValue] = self.encoder.box(value)
+            container[_converted(key).stringValue] = encoder.box(value)
         }
     }
     
     public mutating func encode(_ value: UInt, forKey key: Key) throws {
-        self.encoder.codingPath.append(key)
+        encoder.codingPath.append(key)
         defer { self.encoder.codingPath.removeLast() }
         guard let strategy = self.encoder.nodeEncodings.last else {
             preconditionFailure("Attempt to access node encoding strategy from empty stack.")
@@ -545,19 +548,19 @@ fileprivate struct _XMLKeyedEncodingContainer<K : CodingKey> : KeyedEncodingCont
         switch strategy(key) {
         case .attribute:
             if let attributesContainer = self.container[_XMLElement.attributesKey] as? NSMutableDictionary {
-                attributesContainer[_converted(key).stringValue] = self.encoder.box(value)
+                attributesContainer[_converted(key).stringValue] = encoder.box(value)
             } else {
                 let attributesContainer = NSMutableDictionary()
-                attributesContainer[_converted(key).stringValue] = self.encoder.box(value)
-                self.container[_XMLElement.attributesKey] = attributesContainer
+                attributesContainer[_converted(key).stringValue] = encoder.box(value)
+                container[_XMLElement.attributesKey] = attributesContainer
             }
         case .element:
-            self.container[_converted(key).stringValue] = self.encoder.box(value)
+            container[_converted(key).stringValue] = encoder.box(value)
         }
     }
     
     public mutating func encode(_ value: UInt8, forKey key: Key) throws {
-        self.encoder.codingPath.append(key)
+        encoder.codingPath.append(key)
         defer { self.encoder.codingPath.removeLast() }
         guard let strategy = self.encoder.nodeEncodings.last else {
             preconditionFailure("Attempt to access node encoding strategy from empty stack.")
@@ -565,19 +568,19 @@ fileprivate struct _XMLKeyedEncodingContainer<K : CodingKey> : KeyedEncodingCont
         switch strategy(key) {
         case .attribute:
             if let attributesContainer = self.container[_XMLElement.attributesKey] as? NSMutableDictionary {
-                attributesContainer[_converted(key).stringValue] = self.encoder.box(value)
+                attributesContainer[_converted(key).stringValue] = encoder.box(value)
             } else {
                 let attributesContainer = NSMutableDictionary()
-                attributesContainer[_converted(key).stringValue] = self.encoder.box(value)
-                self.container[_XMLElement.attributesKey] = attributesContainer
+                attributesContainer[_converted(key).stringValue] = encoder.box(value)
+                container[_XMLElement.attributesKey] = attributesContainer
             }
         case .element:
-            self.container[_converted(key).stringValue] = self.encoder.box(value)
+            container[_converted(key).stringValue] = encoder.box(value)
         }
     }
     
     public mutating func encode(_ value: UInt16, forKey key: Key) throws {
-        self.encoder.codingPath.append(key)
+        encoder.codingPath.append(key)
         defer { self.encoder.codingPath.removeLast() }
         guard let strategy = self.encoder.nodeEncodings.last else {
             preconditionFailure("Attempt to access node encoding strategy from empty stack.")
@@ -585,19 +588,19 @@ fileprivate struct _XMLKeyedEncodingContainer<K : CodingKey> : KeyedEncodingCont
         switch strategy(key) {
         case .attribute:
             if let attributesContainer = self.container[_XMLElement.attributesKey] as? NSMutableDictionary {
-                attributesContainer[_converted(key).stringValue] = self.encoder.box(value)
+                attributesContainer[_converted(key).stringValue] = encoder.box(value)
             } else {
                 let attributesContainer = NSMutableDictionary()
-                attributesContainer[_converted(key).stringValue] = self.encoder.box(value)
-                self.container[_XMLElement.attributesKey] = attributesContainer
+                attributesContainer[_converted(key).stringValue] = encoder.box(value)
+                container[_XMLElement.attributesKey] = attributesContainer
             }
         case .element:
-            self.container[_converted(key).stringValue] = self.encoder.box(value)
+            container[_converted(key).stringValue] = encoder.box(value)
         }
     }
     
     public mutating func encode(_ value: UInt32, forKey key: Key) throws {
-        self.encoder.codingPath.append(key)
+        encoder.codingPath.append(key)
         defer { self.encoder.codingPath.removeLast() }
         guard let strategy = self.encoder.nodeEncodings.last else {
             preconditionFailure("Attempt to access node encoding strategy from empty stack.")
@@ -605,19 +608,19 @@ fileprivate struct _XMLKeyedEncodingContainer<K : CodingKey> : KeyedEncodingCont
         switch strategy(key) {
         case .attribute:
             if let attributesContainer = self.container[_XMLElement.attributesKey] as? NSMutableDictionary {
-                attributesContainer[_converted(key).stringValue] = self.encoder.box(value)
+                attributesContainer[_converted(key).stringValue] = encoder.box(value)
             } else {
                 let attributesContainer = NSMutableDictionary()
-                attributesContainer[_converted(key).stringValue] = self.encoder.box(value)
-                self.container[_XMLElement.attributesKey] = attributesContainer
+                attributesContainer[_converted(key).stringValue] = encoder.box(value)
+                container[_XMLElement.attributesKey] = attributesContainer
             }
         case .element:
-            self.container[_converted(key).stringValue] = self.encoder.box(value)
+            container[_converted(key).stringValue] = encoder.box(value)
         }
     }
     
     public mutating func encode(_ value: UInt64, forKey key: Key) throws {
-        self.encoder.codingPath.append(key)
+        encoder.codingPath.append(key)
         defer { self.encoder.codingPath.removeLast() }
         guard let strategy = self.encoder.nodeEncodings.last else {
             preconditionFailure("Attempt to access node encoding strategy from empty stack.")
@@ -625,19 +628,19 @@ fileprivate struct _XMLKeyedEncodingContainer<K : CodingKey> : KeyedEncodingCont
         switch strategy(key) {
         case .attribute:
             if let attributesContainer = self.container[_XMLElement.attributesKey] as? NSMutableDictionary {
-                attributesContainer[_converted(key).stringValue] = self.encoder.box(value)
+                attributesContainer[_converted(key).stringValue] = encoder.box(value)
             } else {
                 let attributesContainer = NSMutableDictionary()
-                attributesContainer[_converted(key).stringValue] = self.encoder.box(value)
-                self.container[_XMLElement.attributesKey] = attributesContainer
+                attributesContainer[_converted(key).stringValue] = encoder.box(value)
+                container[_XMLElement.attributesKey] = attributesContainer
             }
         case .element:
-            self.container[_converted(key).stringValue] = self.encoder.box(value)
+            container[_converted(key).stringValue] = encoder.box(value)
         }
     }
     
     public mutating func encode(_ value: String, forKey key: Key) throws {
-        self.encoder.codingPath.append(key)
+        encoder.codingPath.append(key)
         defer { self.encoder.codingPath.removeLast() }
         guard let strategy = self.encoder.nodeEncodings.last else {
             preconditionFailure("Attempt to access node encoding strategy from empty stack.")
@@ -645,27 +648,27 @@ fileprivate struct _XMLKeyedEncodingContainer<K : CodingKey> : KeyedEncodingCont
         switch strategy(key) {
         case .attribute:
             if let attributesContainer = self.container[_XMLElement.attributesKey] as? NSMutableDictionary {
-                attributesContainer[_converted(key).stringValue] = self.encoder.box(value)
+                attributesContainer[_converted(key).stringValue] = encoder.box(value)
             } else {
                 let attributesContainer = NSMutableDictionary()
-                attributesContainer[_converted(key).stringValue] = self.encoder.box(value)
-                self.container[_XMLElement.attributesKey] = attributesContainer
+                attributesContainer[_converted(key).stringValue] = encoder.box(value)
+                container[_XMLElement.attributesKey] = attributesContainer
             }
         case .element:
-            self.container[_converted(key).stringValue] = self.encoder.box(value)
+            container[_converted(key).stringValue] = encoder.box(value)
         }
     }
     
     public mutating func encode(_ value: Float, forKey key: Key) throws {
         // Since the float may be invalid and throw, the coding path needs to contain this key.
-        self.encoder.codingPath.append(key)
+        encoder.codingPath.append(key)
         defer { self.encoder.codingPath.removeLast() }
-        self.container[_converted(key).stringValue] = try self.encoder.box(value)
+        container[_converted(key).stringValue] = try encoder.box(value)
     }
     
     public mutating func encode(_ value: Double, forKey key: Key) throws {
         // Since the double may be invalid and throw, the coding path needs to contain this key.
-        self.encoder.codingPath.append(key)
+        encoder.codingPath.append(key)
         defer { self.encoder.codingPath.removeLast() }
         guard let strategy = self.encoder.nodeEncodings.last else {
             preconditionFailure("Attempt to access node encoding strategy from empty stack.")
@@ -673,42 +676,42 @@ fileprivate struct _XMLKeyedEncodingContainer<K : CodingKey> : KeyedEncodingCont
         switch strategy(key) {
         case .attribute:
             if let attributesContainer = self.container[_XMLElement.attributesKey] as? NSMutableDictionary {
-                attributesContainer[_converted(key).stringValue] = try self.encoder.box(value)
+                attributesContainer[_converted(key).stringValue] = try encoder.box(value)
             } else {
                 let attributesContainer = NSMutableDictionary()
-                attributesContainer[_converted(key).stringValue] = try self.encoder.box(value)
-                self.container[_XMLElement.attributesKey] = attributesContainer
+                attributesContainer[_converted(key).stringValue] = try encoder.box(value)
+                container[_XMLElement.attributesKey] = attributesContainer
             }
         case .element:
-            self.container[_converted(key).stringValue] = try self.encoder.box(value)
+            container[_converted(key).stringValue] = try encoder.box(value)
         }
     }
     
-    public mutating func encode<T : Encodable>(_ value: T, forKey key: Key) throws {
+    public mutating func encode<T: Encodable>(_ value: T, forKey key: Key) throws {
         guard let strategy = self.encoder.nodeEncodings.last else {
             preconditionFailure("Attempt to access node encoding strategy from empty stack.")
         }
-        self.encoder.codingPath.append(key)
-        let nodeEncodings = self.encoder.options.nodeEncodingStrategy.nodeEncodings(
+        encoder.codingPath.append(key)
+        let nodeEncodings = encoder.options.nodeEncodingStrategy.nodeEncodings(
             forType: T.self,
-            with: self.encoder
+            with: encoder
         )
-        self.encoder.nodeEncodings.append(nodeEncodings)
+        encoder.nodeEncodings.append(nodeEncodings)
         defer {
-            let _ = self.encoder.nodeEncodings.removeLast()
+            _ = self.encoder.nodeEncodings.removeLast()
             self.encoder.codingPath.removeLast()
         }
         switch strategy(key) {
         case .attribute:
             if let attributesContainer = self.container[_XMLElement.attributesKey] as? NSMutableDictionary {
-                attributesContainer[_converted(key).stringValue] = try self.encoder.box(value)
+                attributesContainer[_converted(key).stringValue] = try encoder.box(value)
             } else {
                 let attributesContainer = NSMutableDictionary()
-                attributesContainer[_converted(key).stringValue] = try self.encoder.box(value)
-                self.container[_XMLElement.attributesKey] = attributesContainer
+                attributesContainer[_converted(key).stringValue] = try encoder.box(value)
+                container[_XMLElement.attributesKey] = attributesContainer
             }
         case .element:
-            self.container[_converted(key).stringValue] = try self.encoder.box(value)
+            container[_converted(key).stringValue] = try encoder.box(value)
         }
     }
     
@@ -716,32 +719,32 @@ fileprivate struct _XMLKeyedEncodingContainer<K : CodingKey> : KeyedEncodingCont
         let dictionary = NSMutableDictionary()
         self.container[_converted(key).stringValue] = dictionary
         
-        self.codingPath.append(key)
+        codingPath.append(key)
         defer { self.codingPath.removeLast() }
         
-        let container = _XMLKeyedEncodingContainer<NestedKey>(referencing: self.encoder, codingPath: self.codingPath, wrapping: dictionary)
+        let container = _XMLKeyedEncodingContainer<NestedKey>(referencing: encoder, codingPath: codingPath, wrapping: dictionary)
         return KeyedEncodingContainer(container)
     }
     
     public mutating func nestedUnkeyedContainer(forKey key: Key) -> UnkeyedEncodingContainer {
         let array = NSMutableArray()
-        self.container[_converted(key).stringValue] = array
+        container[_converted(key).stringValue] = array
         
-        self.codingPath.append(key)
+        codingPath.append(key)
         defer { self.codingPath.removeLast() }
-        return _XMLUnkeyedEncodingContainer(referencing: self.encoder, codingPath: self.codingPath, wrapping: array)
+        return _XMLUnkeyedEncodingContainer(referencing: encoder, codingPath: codingPath, wrapping: array)
     }
     
     public mutating func superEncoder() -> Encoder {
-        return _XMLReferencingEncoder(referencing: self.encoder, key: _XMLKey.super, convertedKey: _converted(_XMLKey.super), wrapping: self.container)
+        return _XMLReferencingEncoder(referencing: encoder, key: _XMLKey.super, convertedKey: _converted(_XMLKey.super), wrapping: container)
     }
     
     public mutating func superEncoder(forKey key: Key) -> Encoder {
-        return _XMLReferencingEncoder(referencing: self.encoder, key: key, convertedKey: _converted(key), wrapping: self.container)
+        return _XMLReferencingEncoder(referencing: encoder, key: key, convertedKey: _converted(key), wrapping: container)
     }
 }
 
-fileprivate struct _XMLUnkeyedEncodingContainer : UnkeyedEncodingContainer {
+fileprivate struct _XMLUnkeyedEncodingContainer: UnkeyedEncodingContainer {
     // MARK: Properties
     
     /// A reference to the encoder we're writing to.
@@ -751,11 +754,11 @@ fileprivate struct _XMLUnkeyedEncodingContainer : UnkeyedEncodingContainer {
     private let container: NSMutableArray
     
     /// The path of coding keys taken to get to this point in encoding.
-    private(set) public var codingPath: [CodingKey]
+    public private(set) var codingPath: [CodingKey]
     
     /// The number of elements encoded into the container.
     public var count: Int {
-        return self.container.count
+        return container.count
     }
     
     // MARK: - Initialization
@@ -769,70 +772,70 @@ fileprivate struct _XMLUnkeyedEncodingContainer : UnkeyedEncodingContainer {
     
     // MARK: - UnkeyedEncodingContainer Methods
     
-    public mutating func encodeNil()             throws { self.container.add(NSNull()) }
-    public mutating func encode(_ value: Bool)   throws { self.container.add(self.encoder.box(value)) }
-    public mutating func encode(_ value: Int)    throws { self.container.add(self.encoder.box(value)) }
-    public mutating func encode(_ value: Int8)   throws { self.container.add(self.encoder.box(value)) }
-    public mutating func encode(_ value: Int16)  throws { self.container.add(self.encoder.box(value)) }
-    public mutating func encode(_ value: Int32)  throws { self.container.add(self.encoder.box(value)) }
-    public mutating func encode(_ value: Int64)  throws { self.container.add(self.encoder.box(value)) }
-    public mutating func encode(_ value: UInt)   throws { self.container.add(self.encoder.box(value)) }
-    public mutating func encode(_ value: UInt8)  throws { self.container.add(self.encoder.box(value)) }
-    public mutating func encode(_ value: UInt16) throws { self.container.add(self.encoder.box(value)) }
-    public mutating func encode(_ value: UInt32) throws { self.container.add(self.encoder.box(value)) }
-    public mutating func encode(_ value: UInt64) throws { self.container.add(self.encoder.box(value)) }
-    public mutating func encode(_ value: String) throws { self.container.add(self.encoder.box(value)) }
+    public mutating func encodeNil() throws { container.add(NSNull()) }
+    public mutating func encode(_ value: Bool) throws { container.add(encoder.box(value)) }
+    public mutating func encode(_ value: Int) throws { container.add(encoder.box(value)) }
+    public mutating func encode(_ value: Int8) throws { container.add(encoder.box(value)) }
+    public mutating func encode(_ value: Int16) throws { container.add(encoder.box(value)) }
+    public mutating func encode(_ value: Int32) throws { container.add(encoder.box(value)) }
+    public mutating func encode(_ value: Int64) throws { container.add(encoder.box(value)) }
+    public mutating func encode(_ value: UInt) throws { container.add(encoder.box(value)) }
+    public mutating func encode(_ value: UInt8) throws { container.add(encoder.box(value)) }
+    public mutating func encode(_ value: UInt16) throws { container.add(encoder.box(value)) }
+    public mutating func encode(_ value: UInt32) throws { container.add(encoder.box(value)) }
+    public mutating func encode(_ value: UInt64) throws { container.add(encoder.box(value)) }
+    public mutating func encode(_ value: String) throws { container.add(encoder.box(value)) }
     
-    public mutating func encode(_ value: Float)  throws {
+    public mutating func encode(_ value: Float) throws {
         // Since the float may be invalid and throw, the coding path needs to contain this key.
-        self.encoder.codingPath.append(_XMLKey(index: self.count))
+        encoder.codingPath.append(_XMLKey(index: count))
         defer { self.encoder.codingPath.removeLast() }
-        self.container.add(try self.encoder.box(value))
+        container.add(try encoder.box(value))
     }
     
     public mutating func encode(_ value: Double) throws {
         // Since the double may be invalid and throw, the coding path needs to contain this key.
-        self.encoder.codingPath.append(_XMLKey(index: self.count))
+        encoder.codingPath.append(_XMLKey(index: count))
         defer { self.encoder.codingPath.removeLast() }
-        self.container.add(try self.encoder.box(value))
+        container.add(try encoder.box(value))
     }
     
-    public mutating func encode<T : Encodable>(_ value: T) throws {
-        self.encoder.codingPath.append(_XMLKey(index: self.count))
-        let nodeEncodings = self.encoder.options.nodeEncodingStrategy.nodeEncodings(
+    public mutating func encode<T: Encodable>(_ value: T) throws {
+        encoder.codingPath.append(_XMLKey(index: count))
+        let nodeEncodings = encoder.options.nodeEncodingStrategy.nodeEncodings(
             forType: T.self,
-            with: self.encoder
+            with: encoder
         )
-        self.encoder.nodeEncodings.append(nodeEncodings)
+        encoder.nodeEncodings.append(nodeEncodings)
         defer {
-            let _ = self.encoder.nodeEncodings.removeLast()
+            _ = self.encoder.nodeEncodings.removeLast()
             self.encoder.codingPath.removeLast()
         }
-        self.container.add(try self.encoder.box(value))
+        container.add(try encoder.box(value))
     }
     
     public mutating func nestedContainer<NestedKey>(keyedBy keyType: NestedKey.Type) -> KeyedEncodingContainer<NestedKey> {
-        self.codingPath.append(_XMLKey(index: self.count))
+        codingPath.append(_XMLKey(index: count))
         defer { self.codingPath.removeLast() }
         
         let dictionary = NSMutableDictionary()
         self.container.add(dictionary)
         
-        let container = _XMLKeyedEncodingContainer<NestedKey>(referencing: self.encoder, codingPath: self.codingPath, wrapping: dictionary)
+        let container = _XMLKeyedEncodingContainer<NestedKey>(referencing: encoder, codingPath: codingPath, wrapping: dictionary)
         return KeyedEncodingContainer(container)
     }
     
     public mutating func nestedUnkeyedContainer() -> UnkeyedEncodingContainer {
-        self.codingPath.append(_XMLKey(index: self.count))
+        codingPath.append(_XMLKey(index: count))
         defer { self.codingPath.removeLast() }
         
         let array = NSMutableArray()
-        self.container.add(array)
-        return _XMLUnkeyedEncodingContainer(referencing: self.encoder, codingPath: self.codingPath, wrapping: array)
+        container.add(array)
+        return _XMLUnkeyedEncodingContainer(referencing: encoder, codingPath: codingPath, wrapping: array)
     }
     
     public mutating func superEncoder() -> Encoder {
-        return _XMLReferencingEncoder(referencing: self.encoder, at: self.container.count, wrapping: self.container)
+        return _XMLReferencingEncoder(referencing: encoder, at: container.count, wrapping: container)
     }
 }
 
@@ -840,100 +843,100 @@ extension _XMLEncoder: SingleValueEncodingContainer {
     // MARK: - SingleValueEncodingContainer Methods
     
     fileprivate func assertCanEncodeNewValue() {
-        precondition(self.canEncodeNewValue, "Attempt to encode value through single value container when previously value already encoded.")
+        precondition(canEncodeNewValue, "Attempt to encode value through single value container when previously value already encoded.")
     }
     
     public func encodeNil() throws {
         assertCanEncodeNewValue()
-        self.storage.push(container: NSNull())
+        storage.push(container: NSNull())
     }
     
     public func encode(_ value: Bool) throws {
         assertCanEncodeNewValue()
-        self.storage.push(container: self.box(value))
+        storage.push(container: box(value))
     }
     
     public func encode(_ value: Int) throws {
         assertCanEncodeNewValue()
-        self.storage.push(container: self.box(value))
+        storage.push(container: box(value))
     }
     
     public func encode(_ value: Int8) throws {
         assertCanEncodeNewValue()
-        self.storage.push(container: self.box(value))
+        storage.push(container: box(value))
     }
     
     public func encode(_ value: Int16) throws {
         assertCanEncodeNewValue()
-        self.storage.push(container: self.box(value))
+        storage.push(container: box(value))
     }
     
     public func encode(_ value: Int32) throws {
         assertCanEncodeNewValue()
-        self.storage.push(container: self.box(value))
+        storage.push(container: box(value))
     }
     
     public func encode(_ value: Int64) throws {
         assertCanEncodeNewValue()
-        self.storage.push(container: self.box(value))
+        storage.push(container: box(value))
     }
     
     public func encode(_ value: UInt) throws {
         assertCanEncodeNewValue()
-        self.storage.push(container: self.box(value))
+        storage.push(container: box(value))
     }
     
     public func encode(_ value: UInt8) throws {
         assertCanEncodeNewValue()
-        self.storage.push(container: self.box(value))
+        storage.push(container: box(value))
     }
     
     public func encode(_ value: UInt16) throws {
         assertCanEncodeNewValue()
-        self.storage.push(container: self.box(value))
+        storage.push(container: box(value))
     }
     
     public func encode(_ value: UInt32) throws {
         assertCanEncodeNewValue()
-        self.storage.push(container: self.box(value))
+        storage.push(container: box(value))
     }
     
     public func encode(_ value: UInt64) throws {
         assertCanEncodeNewValue()
-        self.storage.push(container: self.box(value))
+        storage.push(container: box(value))
     }
     
     public func encode(_ value: String) throws {
         assertCanEncodeNewValue()
-        self.storage.push(container: self.box(value))
+        storage.push(container: box(value))
     }
     
     public func encode(_ value: Float) throws {
         assertCanEncodeNewValue()
-        try self.storage.push(container: self.box(value))
+        try storage.push(container: box(value))
     }
     
     public func encode(_ value: Double) throws {
         assertCanEncodeNewValue()
-        try self.storage.push(container: self.box(value))
+        try storage.push(container: box(value))
     }
     
-    public func encode<T : Encodable>(_ value: T) throws {
+    public func encode<T: Encodable>(_ value: T) throws {
         assertCanEncodeNewValue()
-        try self.storage.push(container: self.box(value))
+        try storage.push(container: box(value))
     }
 }
 
 extension _XMLEncoder {
     /// Returns the given value boxed in a container appropriate for pushing onto the container stack.
-    fileprivate func box(_ value: Bool)   -> NSObject { return NSNumber(value: value) }
-    fileprivate func box(_ value: Int)    -> NSObject { return NSNumber(value: value) }
-    fileprivate func box(_ value: Int8)   -> NSObject { return NSNumber(value: value) }
-    fileprivate func box(_ value: Int16)  -> NSObject { return NSNumber(value: value) }
-    fileprivate func box(_ value: Int32)  -> NSObject { return NSNumber(value: value) }
-    fileprivate func box(_ value: Int64)  -> NSObject { return NSNumber(value: value) }
-    fileprivate func box(_ value: UInt)   -> NSObject { return NSNumber(value: value) }
-    fileprivate func box(_ value: UInt8)  -> NSObject { return NSNumber(value: value) }
+    fileprivate func box(_ value: Bool) -> NSObject { return NSNumber(value: value) }
+    fileprivate func box(_ value: Int) -> NSObject { return NSNumber(value: value) }
+    fileprivate func box(_ value: Int8) -> NSObject { return NSNumber(value: value) }
+    fileprivate func box(_ value: Int16) -> NSObject { return NSNumber(value: value) }
+    fileprivate func box(_ value: Int32) -> NSObject { return NSNumber(value: value) }
+    fileprivate func box(_ value: Int64) -> NSObject { return NSNumber(value: value) }
+    fileprivate func box(_ value: UInt) -> NSObject { return NSNumber(value: value) }
+    fileprivate func box(_ value: UInt8) -> NSObject { return NSNumber(value: value) }
     fileprivate func box(_ value: UInt16) -> NSObject { return NSNumber(value: value) }
     fileprivate func box(_ value: UInt32) -> NSObject { return NSNumber(value: value) }
     fileprivate func box(_ value: UInt64) -> NSObject { return NSNumber(value: value) }
@@ -941,7 +944,7 @@ extension _XMLEncoder {
     
     internal func box(_ value: Float) throws -> NSObject {
         if value.isInfinite || value.isNaN {
-            guard case let .convertToString(positiveInfinity: posInfString, negativeInfinity: negInfString, nan: nanString) = self.options.nonConformingFloatEncodingStrategy else {
+            guard case let .convertToString(positiveInfinity: posInfString, negativeInfinity: negInfString, nan: nanString) = options.nonConformingFloatEncodingStrategy else {
                 throw EncodingError._invalidFloatingPointValue(value, at: codingPath)
             }
             
@@ -959,7 +962,7 @@ extension _XMLEncoder {
     
     internal func box(_ value: Double) throws -> NSObject {
         if value.isInfinite || value.isNaN {
-            guard case let .convertToString(positiveInfinity: posInfString, negativeInfinity: negInfString, nan: nanString) = self.options.nonConformingFloatEncodingStrategy else {
+            guard case let .convertToString(positiveInfinity: posInfString, negativeInfinity: negInfString, nan: nanString) = options.nonConformingFloatEncodingStrategy else {
                 throw EncodingError._invalidFloatingPointValue(value, at: codingPath)
             }
             
@@ -976,10 +979,10 @@ extension _XMLEncoder {
     }
     
     internal func box(_ value: Date) throws -> NSObject {
-        switch self.options.dateEncodingStrategy {
+        switch options.dateEncodingStrategy {
         case .deferredToDate:
             try value.encode(to: self)
-            return self.storage.popContainer()
+            return storage.popContainer()
         case .secondsSince1970:
             return NSNumber(value: value.timeIntervalSince1970)
         case .millisecondsSince1970:
@@ -990,60 +993,59 @@ extension _XMLEncoder {
             } else {
                 fatalError("ISO8601DateFormatter is unavailable on this platform.")
             }
-        case .formatted(let formatter):
+        case let .formatted(formatter):
             return formatter.string(from: value) as NSObject
-        case .custom(let closure):
-            let depth = self.storage.count
+        case let .custom(closure):
+            let depth = storage.count
             try closure(value, self)
-
-            guard self.storage.count > depth else { return NSDictionary() }
-
-            return self.storage.popContainer()
+            
+            guard storage.count > depth else { return NSDictionary() }
+            
+            return storage.popContainer()
         }
     }
     
     internal func box(_ value: Data) throws -> NSObject {
-        switch self.options.dataEncodingStrategy {
+        switch options.dataEncodingStrategy {
         case .deferredToData:
             try value.encode(to: self)
-            return self.storage.popContainer()
+            return storage.popContainer()
         case .base64:
             return value.base64EncodedString() as NSObject
-        case .custom(let closure):
-            let depth = self.storage.count
+        case let .custom(closure):
+            let depth = storage.count
             try closure(value, self)
-
-            guard self.storage.count > depth else { return NSDictionary() }
-
-            return self.storage.popContainer() as NSObject
+            
+            guard storage.count > depth else { return NSDictionary() }
+            
+            return storage.popContainer() as NSObject
         }
     }
     
-    fileprivate func box<T : Encodable>(_ value: T) throws -> NSObject {
-        return try self.box_(value) ?? NSDictionary()
+    fileprivate func box<T: Encodable>(_ value: T) throws -> NSObject {
+        return try box_(value) ?? NSDictionary()
     }
     
     // This method is called "box_" instead of "box" to disambiguate it from the overloads. Because the return type here is different from all of the "box" overloads (and is more general), any "box" calls in here would call back into "box" recursively instead of calling the appropriate overload, which is not what we want.
-    fileprivate func box_<T : Encodable>(_ value: T) throws -> NSObject? {
+    fileprivate func box_<T: Encodable>(_ value: T) throws -> NSObject? {
         if T.self == Date.self || T.self == NSDate.self {
-            return try self.box((value as! Date))
+            return try box((value as! Date))
         } else if T.self == Data.self || T.self == NSData.self {
-            return try self.box((value as! Data))
+            return try box((value as! Data))
         } else if T.self == URL.self || T.self == NSURL.self {
-            return self.box((value as! URL).absoluteString)
+            return box((value as! URL).absoluteString)
         } else if T.self == Decimal.self || T.self == NSDecimalNumber.self {
             return (value as! NSDecimalNumber)
         }
         
-        let depth = self.storage.count
+        let depth = storage.count
         try value.encode(to: self)
         
         // The top container should be a new container.
-        guard self.storage.count > depth else {
+        guard storage.count > depth else {
             return nil
         }
         
-        return self.storage.popContainer()
+        return storage.popContainer()
     }
 }
-

--- a/Sources/XMLCoder/Encoder/XMLEncodingStorage.swift
+++ b/Sources/XMLCoder/Encoder/XMLEncodingStorage.swift
@@ -16,7 +16,7 @@ internal struct _XMLEncodingStorage {
     
     /// The container stack.
     /// Elements may be any one of the XML types (NSNull, NSNumber, NSString, NSArray, NSDictionary).
-    private(set) internal var containers: [NSObject] = []
+    internal private(set) var containers: [NSObject] = []
     
     // MARK: - Initialization
     
@@ -26,27 +26,27 @@ internal struct _XMLEncodingStorage {
     // MARK: - Modifying the Stack
     
     internal var count: Int {
-        return self.containers.count
+        return containers.count
     }
     
     internal mutating func pushKeyedContainer() -> NSMutableDictionary {
         let dictionary = NSMutableDictionary()
-        self.containers.append(dictionary)
+        containers.append(dictionary)
         return dictionary
     }
     
     internal mutating func pushUnkeyedContainer() -> NSMutableArray {
         let array = NSMutableArray()
-        self.containers.append(array)
+        containers.append(array)
         return array
     }
     
     internal mutating func push(container: NSObject) {
-        self.containers.append(container)
+        containers.append(container)
     }
     
     internal mutating func popContainer() -> NSObject {
-        precondition(!self.containers.isEmpty, "Empty container stack.")
-        return self.containers.popLast()!
+        precondition(!containers.isEmpty, "Empty container stack.")
+        return containers.popLast()!
     }
 }

--- a/Sources/XMLCoder/Encoder/XMLReferencingEncoder.swift
+++ b/Sources/XMLCoder/Encoder/XMLReferencingEncoder.swift
@@ -12,7 +12,7 @@ import Foundation
 
 /// _XMLReferencingEncoder is a special subclass of _XMLEncoder which has its own storage, but references the contents of a different encoder.
 /// It's used in superEncoder(), which returns a new encoder for encoding a superclass -- the lifetime of the encoder should not escape the scope it's created in, but it doesn't necessarily know when it's done being used (to write to the original container).
-internal class _XMLReferencingEncoder : _XMLEncoder {
+internal class _XMLReferencingEncoder: _XMLEncoder {
     // MARK: Reference types.
     
     /// The type of container we're referencing.
@@ -41,14 +41,14 @@ internal class _XMLReferencingEncoder : _XMLEncoder {
         wrapping array: NSMutableArray
     ) {
         self.encoder = encoder
-        self.reference = .array(array, index)
+        reference = .array(array, index)
         super.init(
             options: encoder.options,
             nodeEncodings: encoder.nodeEncodings,
             codingPath: encoder.codingPath
         )
         
-        self.codingPath.append(_XMLKey(index: index))
+        codingPath.append(_XMLKey(index: index))
     }
     
     /// Initializes `self` by referencing the given dictionary container in the given encoder.
@@ -59,14 +59,14 @@ internal class _XMLReferencingEncoder : _XMLEncoder {
         wrapping dictionary: NSMutableDictionary
     ) {
         self.encoder = encoder
-        self.reference = .dictionary(dictionary, convertedKey.stringValue)
+        reference = .dictionary(dictionary, convertedKey.stringValue)
         super.init(
             options: encoder.options,
             nodeEncodings: encoder.nodeEncodings,
             codingPath: encoder.codingPath
         )
         
-        self.codingPath.append(key)
+        codingPath.append(key)
     }
     
     // MARK: - Coding Path Operations
@@ -75,7 +75,7 @@ internal class _XMLReferencingEncoder : _XMLEncoder {
         // With a regular encoder, the storage and coding path grow together.
         // A referencing encoder, however, inherits its parents coding path, as well as the key it was created for.
         // We have to take this into account.
-        return self.storage.count == self.codingPath.count - self.encoder.codingPath.count - 1
+        return storage.count == codingPath.count - encoder.codingPath.count - 1
     }
     
     // MARK: - Deinitialization
@@ -90,10 +90,10 @@ internal class _XMLReferencingEncoder : _XMLEncoder {
         }
         
         switch self.reference {
-        case .array(let array, let index):
+        case let .array(array, index):
             array.insert(value, at: index)
             
-        case .dictionary(let dictionary, let key):
+        case let .dictionary(dictionary, key):
             dictionary[NSString(string: key)] = value
         }
     }

--- a/Sources/XMLCoder/ISO8601DateFormatter.swift
+++ b/Sources/XMLCoder/ISO8601DateFormatter.swift
@@ -19,5 +19,3 @@ internal var _iso8601Formatter: ISO8601DateFormatter = {
     formatter.formatOptions = .withInternetDateTime
     return formatter
 }()
-
-

--- a/Sources/XMLCoder/XMLKey.swift
+++ b/Sources/XMLCoder/XMLKey.swift
@@ -12,17 +12,17 @@ import Foundation
 // Shared Key Types
 //===----------------------------------------------------------------------===//
 
-internal struct _XMLKey : CodingKey {
+internal struct _XMLKey: CodingKey {
     public var stringValue: String
     public var intValue: Int?
-
+    
     public init?(stringValue: String) {
         self.stringValue = stringValue
-        self.intValue = nil
+        intValue = nil
     }
-
+    
     public init?(intValue: Int) {
-        self.stringValue = "\(intValue)"
+        stringValue = "\(intValue)"
         self.intValue = intValue
     }
     
@@ -30,13 +30,11 @@ internal struct _XMLKey : CodingKey {
         self.stringValue = stringValue
         self.intValue = intValue
     }
-
+    
     internal init(index: Int) {
-        self.stringValue = "Index \(index)"
-        self.intValue = index
+        stringValue = "Index \(index)"
+        intValue = index
     }
-
+    
     internal static let `super` = _XMLKey(stringValue: "super")!
 }
-
-

--- a/Sources/XMLCoder/XMLStackParser.swift
+++ b/Sources/XMLCoder/XMLStackParser.swift
@@ -155,28 +155,28 @@ internal class _XMLElement {
     
     fileprivate func flatten(with charDataKey: String? = nil) -> [String: Any] {
         var node: [String: Any] = attributes
-
-		if children.isEmpty {
-			if let key = charDataKey {
-				node[key] = value
-			}
-		}
-
+        
+        if children.isEmpty {
+            if let key = charDataKey {
+                node[key] = value
+            }
+        }
+        
         for childElement in children {
             for child in childElement.value {
                 if let content = child.value {
                     if let oldContent = node[childElement.key] as? Array<Any> {
                         node[childElement.key] = oldContent + [content]
-
+                        
                     } else if let oldContent = node[childElement.key] {
                         node[childElement.key] = [oldContent, content]
-
+                        
                     } else {
                         node[childElement.key] = content
                     }
                 } else if !child.children.isEmpty || !child.attributes.isEmpty {
                     let newValue = child.flatten()
-
+                    
                     if let existingValue = node[childElement.key] {
                         if var array = existingValue as? Array<Any> {
                             array.append(newValue)
@@ -316,29 +316,29 @@ internal class _XMLStackParser: NSObject, XMLParserDelegate {
     var currentElementName: String?
     var currentElementData = ""
     
-	/// Parses the XML data and returns a dictionary of the parsed output
-	///
-	/// - Parameters:
-	///   - data: The Data to be parsed
-	///   - charDataToken: The token to key the charData in mixed content elements off of
-	/// - Returns: Dictionary of the parsed XML
-	/// - Throws: DecodingError if there's an issue parsing the XML
-	/// - Note:
-	/// When an XML Element has both attributes and child elements, the CharData within the element will be keyed with the `characterDataToken`
-	/// The following XML has both attribute data, child elements, and character data:
-	/// ```
-	/// <SomeElement SomeAttribute="value">
-	///    some string value
-	///    <SomeOtherElement>valuevalue</SomeOtherElement>
-	/// </SomeElement>
-	/// ```
-	/// The "some string value" will be keyed on "CharData"
-	static func parse(with data: Data, charDataToken: String? = nil) throws -> [String: Any] {
+    /// Parses the XML data and returns a dictionary of the parsed output
+    ///
+    /// - Parameters:
+    ///   - data: The Data to be parsed
+    ///   - charDataToken: The token to key the charData in mixed content elements off of
+    /// - Returns: Dictionary of the parsed XML
+    /// - Throws: DecodingError if there's an issue parsing the XML
+    /// - Note:
+    /// When an XML Element has both attributes and child elements, the CharData within the element will be keyed with the `characterDataToken`
+    /// The following XML has both attribute data, child elements, and character data:
+    /// ```
+    /// <SomeElement SomeAttribute="value">
+    ///    some string value
+    ///    <SomeOtherElement>valuevalue</SomeOtherElement>
+    /// </SomeElement>
+    /// ```
+    /// The "some string value" will be keyed on "CharData"
+    static func parse(with data: Data, charDataToken: String? = nil) throws -> [String: Any] {
         let parser = _XMLStackParser()
         
         do {
             if let node = try parser.parse(with: data) {
-				return node.flatten(with: charDataToken)
+                return node.flatten(with: charDataToken)
             } else {
                 throw DecodingError.dataCorrupted(DecodingError.Context(codingPath: [], debugDescription: "The given data could not be parsed into XML."))
             }

--- a/Sources/XMLCoder/XMLStackParser.swift
+++ b/Sources/XMLCoder/XMLStackParser.swift
@@ -153,24 +153,30 @@ internal class _XMLElement {
         parentElement.children[key] = (parentElement.children[key] ?? []) + [element]
     }
     
-    fileprivate func flatten() -> [String: Any] {
+    fileprivate func flatten(with charDataKey: String? = nil) -> [String: Any] {
         var node: [String: Any] = attributes
-        
+
+		if children.isEmpty {
+			if let key = charDataKey {
+				node[key] = value
+			}
+		}
+
         for childElement in children {
             for child in childElement.value {
                 if let content = child.value {
                     if let oldContent = node[childElement.key] as? Array<Any> {
                         node[childElement.key] = oldContent + [content]
-                        
+
                     } else if let oldContent = node[childElement.key] {
                         node[childElement.key] = [oldContent, content]
-                        
+
                     } else {
                         node[childElement.key] = content
                     }
                 } else if !child.children.isEmpty || !child.attributes.isEmpty {
                     let newValue = child.flatten()
-                    
+
                     if let existingValue = node[childElement.key] {
                         if var array = existingValue as? Array<Any> {
                             array.append(newValue)
@@ -254,12 +260,29 @@ internal class _XMLStackParser: NSObject, XMLParserDelegate {
     var currentElementName: String?
     var currentElementData = ""
     
-    static func parse(with data: Data) throws -> [String: Any] {
+	/// Parses the XML data and returns a dictionary of the parsed output
+	///
+	/// - Parameters:
+	///   - data: The Data to be parsed
+	///   - charDataToken: The token to key the charData in mixed content elements off of
+	/// - Returns: Dictionary of the parsed XML
+	/// - Throws: DecodingError if there's an issue parsing the XML
+	/// - Note:
+	/// When an XML Element has both attributes and child elements, the CharData within the element will be keyed with the `characterDataToken`
+	/// The following XML has both attribute data, child elements, and character data:
+	/// ```
+	/// <SomeElement SomeAttribute="value">
+	///    some string value
+	///    <SomeOtherElement>valuevalue</SomeOtherElement>
+	/// </SomeElement>
+	/// ```
+	/// The "some string value" will be keyed on "CharData"
+	static func parse(with data: Data, charDataToken: String? = nil) throws -> [String: Any] {
         let parser = _XMLStackParser()
         
         do {
             if let node = try parser.parse(with: data) {
-                return node.flatten()
+				return node.flatten(with: charDataToken)
             } else {
                 throw DecodingError.dataCorrupted(DecodingError.Context(codingPath: [], debugDescription: "The given data could not be parsed into XML."))
             }

--- a/Tests/XMLCoderTests/CharacterDataDecodingTestCase.swift
+++ b/Tests/XMLCoderTests/CharacterDataDecodingTestCase.swift
@@ -1,34 +1,32 @@
 import Foundation
-import XMLCoder
 import XCTest
+import XMLCoder
 
 class CharacterDataDecodingTestCase: DecodingTestCase {
-
-	override func setUp() {
-		super.setUp()
-		decoder.characterDataToken = "#text"
-	}
-
-	func testItDecodesCharData() {
-		// given
-		struct Attribute: Decodable, Equatable {
-			enum CodingKeys: String, CodingKey {
-				case name = "name"
-				case value = "#text"
-			}
-
-			let name: String
-			let value: String
-		}
-		let xml = """
-<attribute name="Xpos">0</attribute>
-"""
-
-		// when
-		let attr: Attribute = try! decode(xml)
-
-		// then
-		XCTAssertEqual(attr, Attribute(name: "Xpos", value: "0"))
-	}
+    override func setUp() {
+        super.setUp()
+        decoder.characterDataToken = "#text"
+    }
+    
+    func testItDecodesCharData() {
+        // given
+        struct Attribute: Decodable, Equatable {
+            enum CodingKeys: String, CodingKey {
+                case name
+                case value = "#text"
+            }
+            
+            let name: String
+            let value: String
+        }
+        let xml = """
+        <attribute name="Xpos">0</attribute>
+        """
+        
+        // when
+        let attr: Attribute = try! decode(xml)
+        
+        // then
+        XCTAssertEqual(attr, Attribute(name: "Xpos", value: "0"))
+    }
 }
-

--- a/Tests/XMLCoderTests/CharacterDataDecodingTestCase.swift
+++ b/Tests/XMLCoderTests/CharacterDataDecodingTestCase.swift
@@ -29,4 +29,42 @@ class CharacterDataDecodingTestCase: DecodingTestCase {
         // then
         XCTAssertEqual(attr, Attribute(name: "Xpos", value: "0"))
     }
+
+	func testItDecodesCharDataWhenNested() {
+		// given
+		struct Item: Decodable, Equatable {
+			enum CodingKeys: String, CodingKey {
+				case id = "ID"
+				case creator = "Creator"
+				case children = "attribute"
+			}
+
+			let id: String
+			let creator: String
+			let children: [Attribute]?
+		}
+
+		struct Attribute: Decodable, Equatable {
+			enum CodingKeys: String, CodingKey {
+				case name
+				case value = "#text"
+			}
+
+			let name: String
+			let value: String?
+		}
+
+		let xml = """
+			<item ID="1542637462" Creator="Francisco Moya">
+			<attribute name="Xpos">0</attribute>
+			</item>
+			"""
+
+		// when
+		let result: Item = try! decode(xml)
+
+		// then
+		let expected = Item(id: "1542637462", creator: "Francisco Moya", children: nil)
+		XCTAssertEqual(result, expected)
+	}
 }

--- a/Tests/XMLCoderTests/CharacterDataDecodingTestCase.swift
+++ b/Tests/XMLCoderTests/CharacterDataDecodingTestCase.swift
@@ -1,0 +1,34 @@
+import Foundation
+import XMLCoder
+import XCTest
+
+class CharacterDataDecodingTestCase: DecodingTestCase {
+
+	override func setUp() {
+		super.setUp()
+		decoder.characterDataToken = "#text"
+	}
+
+	func testItDecodesCharData() {
+		// given
+		struct Attribute: Decodable, Equatable {
+			enum CodingKeys: String, CodingKey {
+				case name = "name"
+				case value = "#text"
+			}
+
+			let name: String
+			let value: String
+		}
+		let xml = """
+<attribute name="Xpos">0</attribute>
+"""
+
+		// when
+		let attr: Attribute = try! decode(xml)
+
+		// then
+		XCTAssertEqual(attr, Attribute(name: "Xpos", value: "0"))
+	}
+}
+

--- a/Tests/XMLCoderTests/DecodingTestCase.swift
+++ b/Tests/XMLCoderTests/DecodingTestCase.swift
@@ -1,0 +1,24 @@
+import Foundation
+import XMLCoder
+import XCTest
+
+class DecodingTestCase: XCTestCase {
+	var decoder: XMLDecoder!
+
+	func decode<T>(_ string: String) throws -> T where T: Decodable {
+		let data = string.data(using: .utf8)!
+		let result: T = try decoder.decode(T.self, from: data)
+		return result
+	}
+
+	override func setUp() {
+		super.setUp()
+		decoder = XMLDecoder()
+	}
+
+	override func tearDown() {
+		decoder = nil
+		super.tearDown()
+	}
+}
+

--- a/Tests/XMLCoderTests/DecodingTestCase.swift
+++ b/Tests/XMLCoderTests/DecodingTestCase.swift
@@ -1,24 +1,23 @@
 import Foundation
-import XMLCoder
 import XCTest
+import XMLCoder
 
 class DecodingTestCase: XCTestCase {
-	var decoder: XMLDecoder!
-
-	func decode<T>(_ string: String) throws -> T where T: Decodable {
-		let data = string.data(using: .utf8)!
-		let result: T = try decoder.decode(T.self, from: data)
-		return result
-	}
-
-	override func setUp() {
-		super.setUp()
-		decoder = XMLDecoder()
-	}
-
-	override func tearDown() {
-		decoder = nil
-		super.tearDown()
-	}
+    var decoder: XMLDecoder!
+    
+    func decode<T>(_ string: String) throws -> T where T: Decodable {
+        let data = string.data(using: .utf8)!
+        let result: T = try decoder.decode(T.self, from: data)
+        return result
+    }
+    
+    override func setUp() {
+        super.setUp()
+        decoder = XMLDecoder()
+    }
+    
+    override func tearDown() {
+        decoder = nil
+        super.tearDown()
+    }
 }
-

--- a/Tests/XMLCoderTests/XMLCoderTests.swift
+++ b/Tests/XMLCoderTests/XMLCoderTests.swift
@@ -20,7 +20,7 @@ let example = """
 
 struct Relationships: Codable {
     let items: [Relationship]
-
+    
     enum CodingKeys: String, CodingKey {
         case items = "relationship"
     }
@@ -32,11 +32,11 @@ struct Relationship: Codable {
         case extendedProperties = "http://schemas.openxmlformats.org/officeDocument/2006/relationships/extended-properties"
         case coreProperties = "http://schemas.openxmlformats.org/package/2006/relationships/metadata/core-properties"
     }
-
+    
     let id: String
     let type: SchemaType
     let target: String
-
+    
     enum CodingKeys: CodingKey {
         case type
         case id
@@ -48,19 +48,18 @@ class XMLCoderTests: XCTestCase {
     func testExample() {
         do {
             guard let data = example.data(using: .utf8) else { return }
-
+            
             let decoder = XMLDecoder()
             decoder.keyDecodingStrategy = .convertFromCapitalized
-
+            
             let rels = try decoder.decode(Relationships.self, from: data)
-
+            
             XCTAssertEqual(rels.items[0].id, "rId1")
         } catch {
             XCTAssert(false, "failed to decode the example: \(error)")
         }
     }
-
-
+    
     static var allTests = [
         ("testExample", testExample),
     ]

--- a/XMLCoder.xcodeproj/project.pbxproj
+++ b/XMLCoder.xcodeproj/project.pbxproj
@@ -21,6 +21,8 @@
 /* End PBXAggregateTarget section */
 
 /* Begin PBXBuildFile section */
+		A52C85E221B4669600EF98B7 /* DecodingTestCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = A52C85E121B4669600EF98B7 /* DecodingTestCase.swift */; };
+		A52C85E421B4778A00EF98B7 /* CharacterDataDecodingTestCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = A52C85E321B4778A00EF98B7 /* CharacterDataDecodingTestCase.swift */; };
 		BFE1C59121A4242300EA0458 /* NodeEncodingStrategyTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = BFE1C58F21A4232100EA0458 /* NodeEncodingStrategyTests.swift */; };
 		OBJ_35 /* Package.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_6 /* Package.swift */; };
 		OBJ_41 /* XMLCoderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_25 /* XMLCoderTests.swift */; };
@@ -57,6 +59,8 @@
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXFileReference section */
+		A52C85E121B4669600EF98B7 /* DecodingTestCase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DecodingTestCase.swift; sourceTree = "<group>"; };
+		A52C85E321B4778A00EF98B7 /* CharacterDataDecodingTestCase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CharacterDataDecodingTestCase.swift; sourceTree = "<group>"; };
 		BFE1C58F21A4232100EA0458 /* NodeEncodingStrategyTests.swift */ = {isa = PBXFileReference; indentWidth = 4; lastKnownFileType = sourcecode.swift; path = NodeEncodingStrategyTests.swift; sourceTree = "<group>"; tabWidth = 4; };
 		D1BCEBCF21943CA6000B550F /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		D1BCEBD021943F09000B550F /* LinuxMain.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = LinuxMain.swift; path = Tests/LinuxMain.swift; sourceTree = "<group>"; };
@@ -127,6 +131,8 @@
 			children = (
 				OBJ_25 /* XMLCoderTests.swift */,
 				BFE1C58F21A4232100EA0458 /* NodeEncodingStrategyTests.swift */,
+				A52C85E321B4778A00EF98B7 /* CharacterDataDecodingTestCase.swift */,
+				A52C85E121B4669600EF98B7 /* DecodingTestCase.swift */,
 			);
 			name = XMLCoderTests;
 			path = Tests/XMLCoderTests;
@@ -294,6 +300,8 @@
 			files = (
 				OBJ_41 /* XMLCoderTests.swift in Sources */,
 				BFE1C59121A4242300EA0458 /* NodeEncodingStrategyTests.swift in Sources */,
+				A52C85E421B4778A00EF98B7 /* CharacterDataDecodingTestCase.swift in Sources */,
+				A52C85E221B4669600EF98B7 /* DecodingTestCase.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};


### PR DESCRIPTION
I realized that the `.sortedKeys` formatting option was being ignored. Sorting keys is a convenient thing to have, particularly when testing—else, comparing against strings breaks all the time.

This PR wants to fix that.

It also adds a `.swiftformat` file. Its contents were inferred automatically by [SwiftFormat](https://www.github.com/nicklockwood/SwiftFormat) itself. I just wanted my contribution to be consistent with the project’s _de facto_ style, but I think all projects benefit from explicit formatting rules—thus this addition.