### PR TITLE
Clean up `XMLStackParser`

### DIFF
--- a/Sources/XMLCoder/Auxiliaries/XMLElement.swift
+++ b/Sources/XMLCoder/Auxiliaries/XMLElement.swift
@@ -209,3 +209,17 @@ internal class _XMLElement {
         return string
     }
 }
+
+extension _XMLElement: Equatable {
+    static func == (lhs: _XMLElement, rhs: _XMLElement) -> Bool {
+        guard
+            lhs.key == rhs.key,
+            lhs.value == rhs.value,
+            lhs.attributes == rhs.attributes,
+            lhs.children == rhs.children
+        else {
+            return false
+        }
+        return true
+    }
+}

--- a/Sources/XMLCoder/Auxiliaries/XMLElement.swift
+++ b/Sources/XMLCoder/Auxiliaries/XMLElement.swift
@@ -72,6 +72,12 @@ internal class _XMLElement {
         
     }
     
+    func append(value string: String) {
+        var value = self.value ?? ""
+        value += string.trimmingCharacters(in: .whitespacesAndNewlines)
+        self.value = value
+    }
+    
     internal func flatten() -> [String: Box] {
         var node: [String: Box] = attributes.mapValues { StringBox($0) }
         

--- a/Sources/XMLCoder/Auxiliaries/XMLStackParser.swift
+++ b/Sources/XMLCoder/Auxiliaries/XMLStackParser.swift
@@ -9,87 +9,92 @@
 import Foundation
 
 internal class _XMLStackParser: NSObject, XMLParserDelegate {
-    var root: _XMLElement?
-    var stack = [_XMLElement]()
-    var currentNode: _XMLElement?
+    var root: _XMLElement? = nil
+    var stack: [_XMLElement] = []
+    var currentNode: _XMLElement? = nil
 
-    var currentElementName: String?
+    var currentElementName: String? = nil
     var currentElementData = ""
 
     static func parse(with data: Data) throws -> [String: Box] {
         let parser = _XMLStackParser()
 
-        do {
-            if let node = try parser.parse(with: data) {
-                return node.flatten()
-            } else {
-                throw DecodingError.dataCorrupted(DecodingError.Context(codingPath: [], debugDescription: "The given data could not be parsed into XML."))
-            }
-        } catch {
-            throw error
+        guard let node = try parser.parse(with: data) else {
+            throw DecodingError.dataCorrupted(DecodingError.Context(
+                codingPath: [],
+                debugDescription: "The given data could not be parsed into XML."
+            ))
         }
+        
+        return node.flatten()
     }
 
     func parse(with data: Data) throws -> _XMLElement? {
         let xmlParser = XMLParser(data: data)
         xmlParser.delegate = self
-
-        if xmlParser.parse() {
-            return root
-        } else if let error = xmlParser.parserError {
-            throw error
-        } else {
+        
+        guard xmlParser.parse() else {
+            if let error = xmlParser.parserError {
+                throw error
+            }
             return nil
         }
+        
+        return root
     }
 
     func parserDidStartDocument(_: XMLParser) {
         root = nil
-        stack = [_XMLElement]()
+        stack = []
     }
 
     func parser(_: XMLParser, didStartElement elementName: String, namespaceURI _: String?, qualifiedName _: String?, attributes attributeDict: [String: String] = [:]) {
         let node = _XMLElement(key: elementName)
         node.attributes = attributeDict
         stack.append(node)
-
-        if let currentNode = currentNode {
-            if currentNode.children[elementName] != nil {
-                currentNode.children[elementName]?.append(node)
-            } else {
-                currentNode.children[elementName] = [node]
-            }
-        }
+        
+        currentNode?.children[elementName, default: []].append(node)
+        
         currentNode = node
     }
 
     func parser(_: XMLParser, didEndElement _: String, namespaceURI _: String?, qualifiedName _: String?) {
-        if let poppedNode = stack.popLast() {
-            if let content = poppedNode.value?.trimmingCharacters(in: CharacterSet.whitespacesAndNewlines) {
-                if content.isEmpty {
-                    poppedNode.value = nil
-                } else {
-                    poppedNode.value = content
-                }
-            }
-
-            if stack.isEmpty {
-                root = poppedNode
-                currentNode = nil
-            } else {
-                currentNode = stack.last
-            }
+        guard let poppedNode = stack.popLast() else {
+            return
         }
+        
+        if let value = poppedNode.value?.trimmingCharacters(in: .whitespacesAndNewlines) {
+            poppedNode.value = value.isEmpty ? nil : value
+        }
+
+        if stack.isEmpty {
+            root = poppedNode
+        }
+        
+        currentNode = stack.last
     }
 
     func parser(_: XMLParser, foundCharacters string: String) {
-        currentNode?.value = (currentNode?.value ?? "") + string
+        guard let currentNode = currentNode else {
+            return
+        }
+        
+        var value = currentNode.value ?? ""
+        value.append(string)
+        currentNode.value = value
     }
 
     func parser(_: XMLParser, foundCDATA CDATABlock: Data) {
-        if let string = String(data: CDATABlock, encoding: .utf8) {
-            currentNode?.value = (currentNode?.value ?? "") + string
+        guard let string = String(data: CDATABlock, encoding: .utf8) else {
+            return
         }
+        guard let currentNode = currentNode else {
+            return
+        }
+        
+        var value = currentNode.value ?? ""
+        value.append(string)
+        currentNode.value = value
     }
 
     func parser(_: XMLParser, parseErrorOccurred parseError: Error) {

--- a/Sources/XMLCoder/Auxiliaries/XMLStackParser.swift
+++ b/Sources/XMLCoder/Auxiliaries/XMLStackParser.swift
@@ -8,7 +8,7 @@
 
 import Foundation
 
-internal class _XMLStackParser: NSObject, XMLParserDelegate {
+internal class _XMLStackParser: NSObject {
     var root: _XMLElement? = nil
     var stack: [_XMLElement] = []
     var currentNode: _XMLElement? = nil
@@ -42,7 +42,9 @@ internal class _XMLStackParser: NSObject, XMLParserDelegate {
         
         return root
     }
+}
 
+extension _XMLStackParser: XMLParserDelegate {
     func parserDidStartDocument(_: XMLParser) {
         root = nil
         stack = []

--- a/Sources/XMLCoder/Auxiliaries/XMLStackParser.swift
+++ b/Sources/XMLCoder/Auxiliaries/XMLStackParser.swift
@@ -51,8 +51,8 @@ extension _XMLStackParser: XMLParserDelegate {
     }
 
     func parser(_: XMLParser, didStartElement elementName: String, namespaceURI _: String?, qualifiedName _: String?, attributes attributeDict: [String: String] = [:]) {
-        let node = _XMLElement(key: elementName)
-        node.attributes = attributeDict
+        let node = _XMLElement(key: elementName, attributes: attributeDict)
+        
         stack.append(node)
         
         currentNode?.children[elementName, default: []].append(node)

--- a/Sources/XMLCoder/Auxiliaries/XMLStackParser.swift
+++ b/Sources/XMLCoder/Auxiliaries/XMLStackParser.swift
@@ -65,7 +65,7 @@ extension _XMLStackParser: XMLParserDelegate {
             return
         }
         
-        if let value = poppedNode.value?.trimmingCharacters(in: .whitespacesAndNewlines) {
+        if let value = poppedNode.value {
             poppedNode.value = value.isEmpty ? nil : value
         }
 
@@ -81,9 +81,7 @@ extension _XMLStackParser: XMLParserDelegate {
             return
         }
         
-        var value = currentNode.value ?? ""
-        value.append(string)
-        currentNode.value = value
+        currentNode.append(value: string)
     }
 
     func parser(_: XMLParser, foundCDATA CDATABlock: Data) {
@@ -94,9 +92,7 @@ extension _XMLStackParser: XMLParserDelegate {
             return
         }
         
-        var value = currentNode.value ?? ""
-        value.append(string)
-        currentNode.value = value
+        currentNode.append(value: string)
     }
 
     func parser(_: XMLParser, parseErrorOccurred parseError: Error) {

--- a/Tests/XMLCoderTests/Auxiliary/XMLStackParserTests.swift
+++ b/Tests/XMLCoderTests/Auxiliary/XMLStackParserTests.swift
@@ -1,0 +1,33 @@
+//
+//  XMLStackParserTests.swift
+//  XMLCoderTests
+//
+//  Created by Vincent Esche on 12/21/18.
+//
+
+import XCTest
+@testable import XMLCoder
+
+class XMLStackParserTests: XCTestCase {
+    func testParseWith() throws {
+        let parser = _XMLStackParser()
+        
+        let xmlString = "<container><value>42</value></container>"
+        let xmlData = xmlString.data(using: .utf8)!
+        
+        let root: _XMLElement? = try parser.parse(with: xmlData)
+        
+        let expected = _XMLElement(
+            key: "container",
+            children: [
+                "value": [
+                    _XMLElement(
+                        key: "value",
+                        value: "42"
+                    )
+                ]
+            ]
+        )
+        XCTAssertEqual(root, expected)
+    }
+}

--- a/XMLCoder.xcodeproj/project.pbxproj
+++ b/XMLCoder.xcodeproj/project.pbxproj
@@ -21,6 +21,7 @@
 /* End PBXAggregateTarget section */
 
 /* Begin PBXBuildFile section */
+		BF63EF0021CCDED2001D38C5 /* XMLStackParserTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = BF63EEFF21CCDED2001D38C5 /* XMLStackParserTests.swift */; };
 		BF9457A821CBB498005ACFDE /* NullBox.swift in Sources */ = {isa = PBXBuildFile; fileRef = BF94579E21CBB497005ACFDE /* NullBox.swift */; };
 		BF9457A921CBB498005ACFDE /* DictionaryBox.swift in Sources */ = {isa = PBXBuildFile; fileRef = BF94579F21CBB497005ACFDE /* DictionaryBox.swift */; };
 		BF9457AA21CBB498005ACFDE /* ArrayBox.swift in Sources */ = {isa = PBXBuildFile; fileRef = BF9457A021CBB497005ACFDE /* ArrayBox.swift */; };
@@ -105,6 +106,7 @@
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXFileReference section */
+		BF63EEFF21CCDED2001D38C5 /* XMLStackParserTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = XMLStackParserTests.swift; sourceTree = "<group>"; };
 		BF94579E21CBB497005ACFDE /* NullBox.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = NullBox.swift; sourceTree = "<group>"; };
 		BF94579F21CBB497005ACFDE /* DictionaryBox.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DictionaryBox.swift; sourceTree = "<group>"; };
 		BF9457A021CBB497005ACFDE /* ArrayBox.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ArrayBox.swift; sourceTree = "<group>"; };
@@ -192,6 +194,14 @@
 /* End PBXFrameworksBuildPhase section */
 
 /* Begin PBXGroup section */
+		BF63EEFE21CCDEC1001D38C5 /* Auxiliary */ = {
+			isa = PBXGroup;
+			children = (
+				BF63EEFF21CCDED2001D38C5 /* XMLStackParserTests.swift */,
+			);
+			path = Auxiliary;
+			sourceTree = "<group>";
+		};
 		BF94578721CBB454005ACFDE /* Box */ = {
 			isa = PBXGroup;
 			children = (
@@ -286,6 +296,7 @@
 			children = (
 				BF9457BD21CBB516005ACFDE /* Box */,
 				BF9457E121CBB6BC005ACFDE /* Minimal */,
+				BF63EEFE21CCDEC1001D38C5 /* Auxiliary */,
 				OBJ_28 /* BooksTest.swift */,
 				OBJ_29 /* BreakfastTest.swift */,
 				OBJ_30 /* CDCatalog.swift */,
@@ -493,6 +504,7 @@
 				OBJ_80 /* BooksTest.swift in Sources */,
 				OBJ_81 /* BreakfastTest.swift in Sources */,
 				OBJ_82 /* CDCatalog.swift in Sources */,
+				BF63EF0021CCDED2001D38C5 /* XMLStackParserTests.swift in Sources */,
 				BF9457CC21CBB516005ACFDE /* NullBoxTests.swift in Sources */,
 				BF9457CF21CBB516005ACFDE /* IntBoxTests.swift in Sources */,
 				BF9457E021CBB68A005ACFDE /* DataBoxTests.swift in Sources */,


### PR DESCRIPTION
This PR consists of mostly migrations from `if let` to `guard let` as well as other semantics-preserving changed to keep the conditional nesting low and make the control flow clear (i.e. the happy/expected path is the one with the least detours into `if` or `if let` blocks).