### PR TITLE
Remove use of explicit `internal`

### DIFF
--- a/Sources/XMLCoder/Auxiliaries/ISO8601DateFormatter.swift
+++ b/Sources/XMLCoder/Auxiliaries/ISO8601DateFormatter.swift
@@ -14,7 +14,7 @@ import Foundation
 /// whichever Foundation the user has. ISO8601DateFormatter might not exist, so
 /// we better not hit this code path on an older OS.
 @available(macOS 10.12, iOS 10.0, watchOS 3.0, tvOS 10.0, *)
-internal var _iso8601Formatter: ISO8601DateFormatter = {
+var _iso8601Formatter: ISO8601DateFormatter = {
     let formatter = ISO8601DateFormatter()
     formatter.formatOptions = .withInternetDateTime
     return formatter

--- a/Sources/XMLCoder/Auxiliaries/String+Extensions.swift
+++ b/Sources/XMLCoder/Auxiliaries/String+Extensions.swift
@@ -8,7 +8,7 @@
 import Foundation
 
 extension String {
-    internal func escape(_ characterSet: [(character: String, escapedCharacter: String)]) -> String {
+    func escape(_ characterSet: [(character: String, escapedCharacter: String)]) -> String {
         var string = self
         
         for set in characterSet {

--- a/Sources/XMLCoder/Auxiliaries/XMLElement.swift
+++ b/Sources/XMLCoder/Auxiliaries/XMLElement.swift
@@ -7,7 +7,7 @@
 
 import Foundation
 
-internal class _XMLElement {
+class _XMLElement {
     static let attributesKey = "___ATTRIBUTES"
     static let escapedCharacterSet = [("&", "&amp"), ("<", "&lt;"), (">", "&gt;"), ("'", "&apos;"), ("\"", "&quot;")]
     
@@ -16,7 +16,7 @@ internal class _XMLElement {
     var attributes: [String: String] = [:]
     var children: [String: [_XMLElement]] = [:]
     
-    internal init(key: String, value: String? = nil, attributes: [String: String] = [:], children: [String: [_XMLElement]] = [:]) {
+    init(key: String, value: String? = nil, attributes: [String: String] = [:], children: [String: [_XMLElement]] = [:]) {
         self.key = key
         self.value = value
         self.attributes = attributes
@@ -78,7 +78,7 @@ internal class _XMLElement {
         self.value = value
     }
     
-    internal func flatten() -> [String: Box] {
+    func flatten() -> [String: Box] {
         var node: [String: Box] = attributes.mapValues { StringBox($0) }
         
         for childElement in children {

--- a/Sources/XMLCoder/Auxiliaries/XMLHeader.swift
+++ b/Sources/XMLCoder/Auxiliaries/XMLHeader.swift
@@ -21,11 +21,11 @@ public struct XMLHeader {
         self.standalone = standalone
     }
     
-    internal func isEmpty() -> Bool {
+    func isEmpty() -> Bool {
         return version == nil && encoding == nil && standalone == nil
     }
     
-    internal func toXML() -> String? {
+    func toXML() -> String? {
         guard !isEmpty() else { return nil }
         
         var string = "<?xml "

--- a/Sources/XMLCoder/Auxiliaries/XMLKey.swift
+++ b/Sources/XMLCoder/Auxiliaries/XMLKey.swift
@@ -9,7 +9,7 @@
 import Foundation
 
 /// Shared Key Types
-internal struct _XMLKey: CodingKey {
+struct _XMLKey: CodingKey {
     public let stringValue: String
     public let intValue: Int?
 
@@ -28,10 +28,10 @@ internal struct _XMLKey: CodingKey {
         self.intValue = intValue
     }
 
-    internal init(index: Int) {
+    init(index: Int) {
         stringValue = "Index \(index)"
         intValue = index
     }
 
-    internal static let `super` = _XMLKey(stringValue: "super")!
+    static let `super` = _XMLKey(stringValue: "super")!
 }

--- a/Sources/XMLCoder/Auxiliaries/XMLStackParser.swift
+++ b/Sources/XMLCoder/Auxiliaries/XMLStackParser.swift
@@ -8,7 +8,7 @@
 
 import Foundation
 
-internal class _XMLStackParser: NSObject {
+class _XMLStackParser: NSObject {
     var root: _XMLElement? = nil
     var stack: [_XMLElement] = []
     var currentNode: _XMLElement? = nil

--- a/Sources/XMLCoder/Decoder/DecodingErrorExtension.swift
+++ b/Sources/XMLCoder/Decoder/DecodingErrorExtension.swift
@@ -12,14 +12,14 @@ import Foundation
 // Error Utilities
 //===----------------------------------------------------------------------===//
 
-internal extension DecodingError {
+extension DecodingError {
     /// Returns a `.typeMismatch` error describing the expected type.
     ///
     /// - parameter path: The path of `CodingKey`s taken to decode a value of this type.
     /// - parameter expectation: The type expected to be encountered.
     /// - parameter reality: The value that was encountered instead of the expected type.
     /// - returns: A `DecodingError` with the appropriate path and debug description.
-    internal static func _typeMismatch(at path: [CodingKey], expectation: Any.Type, reality: Box) -> DecodingError {
+    static func _typeMismatch(at path: [CodingKey], expectation: Any.Type, reality: Box) -> DecodingError {
         let description = "Expected to decode \(expectation) but found \(_typeDescription(of: reality)) instead."
         return .typeMismatch(expectation, Context(codingPath: path, debugDescription: description))
     }
@@ -29,7 +29,7 @@ internal extension DecodingError {
     /// - parameter value: The value whose type to describe.
     /// - returns: A string describing `value`.
     /// - precondition: `value` is one of the types below.
-    internal static func _typeDescription(of box: Box) -> String {
+    static func _typeDescription(of box: Box) -> String {
         switch box {
         case is NullBox:
             return "a null value"

--- a/Sources/XMLCoder/Decoder/XMLDecoder.swift
+++ b/Sources/XMLCoder/Decoder/XMLDecoder.swift
@@ -211,7 +211,7 @@ open class XMLDecoder {
     open var userInfo: [CodingUserInfoKey: Any] = [:]
 
     /// Options set on the top-level encoder to pass down the decoding hierarchy.
-    internal struct _Options {
+    struct _Options {
         let dateDecodingStrategy: DateDecodingStrategy
         let dataDecodingStrategy: DataDecodingStrategy
         let nonConformingFloatDecodingStrategy: NonConformingFloatDecodingStrategy
@@ -220,7 +220,7 @@ open class XMLDecoder {
     }
 
     /// The options set on the top-level decoder.
-    internal var options: _Options {
+    var options: _Options {
         return _Options(dateDecodingStrategy: dateDecodingStrategy,
                         dataDecodingStrategy: dataDecodingStrategy,
                         nonConformingFloatDecodingStrategy: nonConformingFloatDecodingStrategy,
@@ -268,14 +268,14 @@ open class XMLDecoder {
 
 // MARK: - _XMLDecoder
 
-internal class _XMLDecoder: Decoder {
+class _XMLDecoder: Decoder {
     // MARK: Properties
 
     /// The decoder's storage.
-    internal var storage: _XMLDecodingStorage
+    var storage: _XMLDecodingStorage
 
     /// Options set on the top-level decoder.
-    internal let options: XMLDecoder._Options
+    let options: XMLDecoder._Options
 
     /// The path to the current point in encoding.
     public internal(set) var codingPath: [CodingKey]
@@ -288,7 +288,7 @@ internal class _XMLDecoder: Decoder {
     // MARK: - Initialization
 
     /// Initializes `self` with the given top-level container and options.
-    internal init(referencing container: Box, at codingPath: [CodingKey] = [], options: XMLDecoder._Options) {
+    init(referencing container: Box, at codingPath: [CodingKey] = [], options: XMLDecoder._Options) {
         storage = _XMLDecodingStorage()
         storage.push(container: container)
         self.codingPath = codingPath
@@ -398,7 +398,7 @@ extension _XMLDecoder: SingleValueDecodingContainer {
 extension _XMLDecoder {
     /// Returns the given box unboxed from a container.
     
-    internal func unbox(_ box: Box) throws -> Bool? {
+    func unbox(_ box: Box) throws -> Bool? {
         guard !box.isNull else { return nil }
         
         guard let string = (box as? StringBox)?.unbox() else { return nil }
@@ -410,7 +410,7 @@ extension _XMLDecoder {
         return boolBox.unbox()
     }
     
-    internal func unbox(_ box: Box) throws -> Decimal? {
+    func unbox(_ box: Box) throws -> Decimal? {
         guard !box.isNull else { return nil }
         
         guard let string = (box as? StringBox)?.unbox() else { return nil }
@@ -422,7 +422,7 @@ extension _XMLDecoder {
         return decimalBox.unbox()
     }
 
-    internal func unbox<T: BinaryInteger & SignedInteger & Decodable>(_ box: Box) throws -> T? {
+    func unbox<T: BinaryInteger & SignedInteger & Decodable>(_ box: Box) throws -> T? {
         guard !box.isNull else { return nil }
         
         guard let string = (box as? StringBox)?.unbox() else { return nil }
@@ -441,7 +441,7 @@ extension _XMLDecoder {
         return int
     }
     
-    internal func unbox<T: BinaryInteger & UnsignedInteger & Decodable>(_ box: Box) throws -> T? {
+    func unbox<T: BinaryInteger & UnsignedInteger & Decodable>(_ box: Box) throws -> T? {
         guard !box.isNull else { return nil }
         
         guard let string = (box as? StringBox)?.unbox() else { return nil }
@@ -460,7 +460,7 @@ extension _XMLDecoder {
         return uint
     }
 
-    internal func unbox<T: BinaryFloatingPoint & Decodable>(_ box: Box) throws -> T? {
+    func unbox<T: BinaryFloatingPoint & Decodable>(_ box: Box) throws -> T? {
         guard !box.isNull else { return nil }
         
         guard let string = (box as? StringBox)?.unbox() else { return nil }
@@ -479,7 +479,7 @@ extension _XMLDecoder {
         return float
     }
 
-    internal func unbox(_ box: Box) throws -> String? {
+    func unbox(_ box: Box) throws -> String? {
         guard !box.isNull else { return nil }
 
         guard let string = (box as? StringBox)?.unbox() else {
@@ -489,7 +489,7 @@ extension _XMLDecoder {
         return string
     }
 
-    internal func unbox(_ box: Box) throws -> Date? {
+    func unbox(_ box: Box) throws -> Date? {
         guard !box.isNull else { return nil }
 
         switch options.dateDecodingStrategy {
@@ -549,7 +549,7 @@ extension _XMLDecoder {
         }
     }
 
-    internal func unbox(_ box: Box) throws -> Data? {
+    func unbox(_ box: Box) throws -> Data? {
         guard !box.isNull else { return nil }
 
         switch options.dataDecodingStrategy {
@@ -576,7 +576,7 @@ extension _XMLDecoder {
         }
     }
 
-    internal func unbox<T: Decodable>(_ box: Box) throws -> T? {
+    func unbox<T: Decodable>(_ box: Box) throws -> T? {
         let decoded: T
         let type = T.self
         if type == Date.self || type == NSDate.self {

--- a/Sources/XMLCoder/Decoder/XMLDecodingStorage.swift
+++ b/Sources/XMLCoder/Decoder/XMLDecodingStorage.swift
@@ -10,7 +10,7 @@ import Foundation
 
 // MARK: - Decoding Storage
 
-internal struct _XMLDecodingStorage {
+struct _XMLDecodingStorage {
     // MARK: Properties
 
     /// The container stack.

--- a/Sources/XMLCoder/Decoder/XMLKeyedDecodingContainer.swift
+++ b/Sources/XMLCoder/Decoder/XMLKeyedDecodingContainer.swift
@@ -19,7 +19,7 @@ extension Dictionary: AnyEmptySequence {}
 
 // MARK: Decoding Containers
 
-internal struct _XMLKeyedDecodingContainer<K: CodingKey>: KeyedDecodingContainerProtocol {
+struct _XMLKeyedDecodingContainer<K: CodingKey>: KeyedDecodingContainerProtocol {
     typealias Key = K
 
     // MARK: Properties
@@ -36,7 +36,7 @@ internal struct _XMLKeyedDecodingContainer<K: CodingKey>: KeyedDecodingContainer
     // MARK: - Initialization
 
     /// Initializes `self` by referencing the given decoder and container.
-    internal init(referencing decoder: _XMLDecoder, wrapping container: KeyedBox) {
+    init(referencing decoder: _XMLDecoder, wrapping container: KeyedBox) {
         self.decoder = decoder
         switch decoder.options.keyDecodingStrategy {
         case .useDefaultKeys:

--- a/Sources/XMLCoder/Decoder/XMLUnkeyedDecodingContainer.swift
+++ b/Sources/XMLCoder/Decoder/XMLUnkeyedDecodingContainer.swift
@@ -8,7 +8,7 @@
 
 import Foundation
 
-internal struct _XMLUnkeyedDecodingContainer: UnkeyedDecodingContainer {
+struct _XMLUnkeyedDecodingContainer: UnkeyedDecodingContainer {
     // MARK: Properties
 
     /// A reference to the decoder we're reading from.
@@ -26,7 +26,7 @@ internal struct _XMLUnkeyedDecodingContainer: UnkeyedDecodingContainer {
     // MARK: - Initialization
 
     /// Initializes `self` by referencing the given decoder and container.
-    internal init(referencing decoder: _XMLDecoder, wrapping container: UnkeyedBox) {
+    init(referencing decoder: _XMLDecoder, wrapping container: UnkeyedBox) {
         self.decoder = decoder
         self.container = container
         codingPath = decoder.codingPath

--- a/Sources/XMLCoder/Encoder/EncodingErrorExtension.swift
+++ b/Sources/XMLCoder/Encoder/EncodingErrorExtension.swift
@@ -9,14 +9,14 @@
 import Foundation
 
 /// Error Utilities
-internal extension EncodingError {
+extension EncodingError {
     /// Returns a `.invalidValue` error describing the given invalid floating-point value.
     ///
     ///
     /// - parameter value: The value that was invalid to encode.
     /// - parameter path: The path of `CodingKey`s taken to encode this value.
     /// - returns: An `EncodingError` with the appropriate path and debug description.
-    internal static func _invalidFloatingPointValue<T: FloatingPoint>(_ value: T, at codingPath: [CodingKey]) -> EncodingError {
+    static func _invalidFloatingPointValue<T: FloatingPoint>(_ value: T, at codingPath: [CodingKey]) -> EncodingError {
         let valueDescription: String
         if value == T.infinity {
             valueDescription = "\(T.self).infinity"

--- a/Sources/XMLCoder/Encoder/XMLEncoder.swift
+++ b/Sources/XMLCoder/Encoder/XMLEncoder.swift
@@ -124,7 +124,7 @@ open class XMLEncoder {
         /// If the result of the conversion is a duplicate key, then only one value will be present in the result.
         case custom((_ codingPath: [CodingKey]) -> CodingKey)
 
-        internal static func _convertToSnakeCase(_ stringKey: String) -> String {
+        static func _convertToSnakeCase(_ stringKey: String) -> String {
             guard !stringKey.isEmpty else { return stringKey }
 
             var words: [Range<String.Index>] = []
@@ -185,7 +185,7 @@ open class XMLEncoder {
         /// Return a closure computing the desired node encoding for the value by its coding key.
         case custom((Encodable.Type, Encoder) -> ((CodingKey) -> XMLEncoder.NodeEncoding))
 
-        internal func nodeEncodings(
+        func nodeEncodings(
             forType codableType: Encodable.Type,
             with encoder: Encoder
         ) -> ((CodingKey) -> XMLEncoder.NodeEncoding) {
@@ -223,7 +223,7 @@ open class XMLEncoder {
     open var userInfo: [CodingUserInfoKey: Any] = [:]
 
     /// Options set on the top-level encoder to pass down the encoding hierarchy.
-    internal struct _Options {
+    struct _Options {
         let dateEncodingStrategy: DateEncodingStrategy
         let dataEncodingStrategy: DataEncodingStrategy
         let nonConformingFloatEncodingStrategy: NonConformingFloatEncodingStrategy
@@ -234,7 +234,7 @@ open class XMLEncoder {
     }
 
     /// The options set on the top-level encoder.
-    internal var options: _Options {
+    var options: _Options {
         return _Options(dateEncodingStrategy: dateEncodingStrategy,
                         dataEncodingStrategy: dataEncodingStrategy,
                         nonConformingFloatEncodingStrategy: nonConformingFloatEncodingStrategy,
@@ -294,14 +294,14 @@ open class XMLEncoder {
     }
 }
 
-internal class _XMLEncoder: Encoder {
+class _XMLEncoder: Encoder {
     // MARK: Properties
 
     /// The encoder's storage.
-    internal var storage: _XMLEncodingStorage
+    var storage: _XMLEncodingStorage
 
     /// Options set on the top-level encoder.
-    internal let options: XMLEncoder._Options
+    let options: XMLEncoder._Options
 
     /// The path to the current point in encoding.
     public var codingPath: [CodingKey]
@@ -316,7 +316,7 @@ internal class _XMLEncoder: Encoder {
     // MARK: - Initialization
 
     /// Initializes `self` with the given top-level encoder options.
-    internal init(
+    init(
         options: XMLEncoder._Options,
         nodeEncodings: [(CodingKey) -> XMLEncoder.NodeEncoding],
         codingPath: [CodingKey] = []
@@ -330,7 +330,7 @@ internal class _XMLEncoder: Encoder {
     /// Returns whether a new element can be encoded at this coding path.
     ///
     /// `true` if an element has not yet been encoded at this coding path; `false` otherwise.
-    internal var canEncodeNewValue: Bool {
+    var canEncodeNewValue: Bool {
         // Every time a new value gets encoded, the key it's encoded for is pushed onto the coding path (even if it's a nil key from an unkeyed container).
         // At the same time, every time a container is requested, a new value gets pushed onto the storage stack.
         // If there are more values on the storage stack than on the coding path, it means the value is requesting more than one container, which violates the precondition.
@@ -385,7 +385,7 @@ internal class _XMLEncoder: Encoder {
 extension _XMLEncoder: SingleValueEncodingContainer {
     // MARK: - SingleValueEncodingContainer Methods
     
-    internal func assertCanEncodeNewValue() {
+    func assertCanEncodeNewValue() {
         precondition(self.canEncodeNewValue, "Attempt to encode value through single value container when previously value already encoded.")
     }
 
@@ -472,27 +472,27 @@ extension _XMLEncoder: SingleValueEncodingContainer {
 
 extension _XMLEncoder {
     /// Returns the given value boxed in a container appropriate for pushing onto the container stack.
-    internal func box() -> SimpleBox {
+    func box() -> SimpleBox {
         return NullBox()
     }
     
-    internal func box(_ value: Bool) -> SimpleBox {
+    func box(_ value: Bool) -> SimpleBox {
         return BoolBox(value)
     }
     
-    internal func box(_ value: Decimal) -> SimpleBox {
+    func box(_ value: Decimal) -> SimpleBox {
         return DecimalBox(value)
     }
     
-    internal func box<T: BinaryInteger & SignedInteger & Encodable>(_ value: T) -> SimpleBox {
+    func box<T: BinaryInteger & SignedInteger & Encodable>(_ value: T) -> SimpleBox {
         return IntBox(value)
     }
     
-    internal func box<T: BinaryInteger & UnsignedInteger & Encodable>(_ value: T) -> SimpleBox {
+    func box<T: BinaryInteger & UnsignedInteger & Encodable>(_ value: T) -> SimpleBox {
         return UIntBox(value)
     }
     
-    internal func box<T: BinaryFloatingPoint & Encodable>(_ value: T) throws -> SimpleBox {
+    func box<T: BinaryFloatingPoint & Encodable>(_ value: T) throws -> SimpleBox {
         guard value.isInfinite || value.isNaN else {
             return FloatBox(value)
         }
@@ -507,12 +507,12 @@ extension _XMLEncoder {
             return StringBox(nanString)
         }
     }
-    
-    internal func box(_ value: String) -> SimpleBox {
+
+    func box(_ value: String) -> SimpleBox {
         return StringBox(value)
     }
     
-    internal func box(_ value: Date) throws -> Box {
+    func box(_ value: Date) throws -> Box {
         switch options.dateEncodingStrategy {
         case .deferredToDate:
             try value.encode(to: self)
@@ -535,7 +535,7 @@ extension _XMLEncoder {
         }
     }
 
-    internal func box(_ value: Data) throws -> Box {
+    func box(_ value: Data) throws -> Box {
         switch options.dataEncodingStrategy {
         case .deferredToData:
             try value.encode(to: self)
@@ -551,8 +551,8 @@ extension _XMLEncoder {
             return storage.popContainer()
         }
     }
-    
-    internal func box<T : Encodable>(_ value: T) throws -> Box {
+
+    func box<T : Encodable>(_ value: T) throws -> Box {
         return try self.boxOrNil(value) ?? KeyedBox()
     }
 

--- a/Sources/XMLCoder/Encoder/XMLEncodingStorage.swift
+++ b/Sources/XMLCoder/Encoder/XMLEncodingStorage.swift
@@ -11,7 +11,7 @@ import Foundation
 
 // MARK: - Encoding Storage and Containers
 
-internal struct _XMLEncodingStorage {
+struct _XMLEncodingStorage {
     // MARK: Properties
 
     /// The container stack.

--- a/Sources/XMLCoder/Encoder/XMLKeyedEncodingContainer.swift
+++ b/Sources/XMLCoder/Encoder/XMLKeyedEncodingContainer.swift
@@ -7,7 +7,7 @@
 
 import Foundation
 
-internal struct _XMLKeyedEncodingContainer<K : CodingKey> : KeyedEncodingContainerProtocol {
+struct _XMLKeyedEncodingContainer<K : CodingKey> : KeyedEncodingContainerProtocol {
     typealias Key = K
     
     // MARK: Properties
@@ -24,7 +24,7 @@ internal struct _XMLKeyedEncodingContainer<K : CodingKey> : KeyedEncodingContain
     // MARK: - Initialization
     
     /// Initializes `self` with the given references.
-    internal init(referencing encoder: _XMLEncoder, codingPath: [CodingKey], wrapping container: KeyedBox) {
+    init(referencing encoder: _XMLEncoder, codingPath: [CodingKey], wrapping container: KeyedBox) {
         self.encoder = encoder
         self.codingPath = codingPath
         self.container = container

--- a/Sources/XMLCoder/Encoder/XMLReferencingEncoder.swift
+++ b/Sources/XMLCoder/Encoder/XMLReferencingEncoder.swift
@@ -12,7 +12,7 @@ import Foundation
 
 /// _XMLReferencingEncoder is a special subclass of _XMLEncoder which has its own storage, but references the contents of a different encoder.
 /// It's used in superEncoder(), which returns a new encoder for encoding a superclass -- the lifetime of the encoder should not escape the scope it's created in, but it doesn't necessarily know when it's done being used (to write to the original container).
-internal class _XMLReferencingEncoder: _XMLEncoder {
+class _XMLReferencingEncoder: _XMLEncoder {
     // MARK: Reference types.
 
     /// The type of container we're referencing.
@@ -27,7 +27,7 @@ internal class _XMLReferencingEncoder: _XMLEncoder {
     // MARK: - Properties
 
     /// The encoder we're referencing.
-    internal let encoder: _XMLEncoder
+    let encoder: _XMLEncoder
 
     /// The container reference itself.
     private let reference: Reference
@@ -35,7 +35,7 @@ internal class _XMLReferencingEncoder: _XMLEncoder {
     // MARK: - Initialization
 
     /// Initializes `self` by referencing the given array container in the given encoder.
-    internal init(
+    init(
         referencing encoder: _XMLEncoder,
         at index: Int,
         wrapping unkeyed: UnkeyedBox
@@ -52,7 +52,7 @@ internal class _XMLReferencingEncoder: _XMLEncoder {
     }
 
     /// Initializes `self` by referencing the given dictionary container in the given encoder.
-    internal init(
+    init(
         referencing encoder: _XMLEncoder,
         key: CodingKey,
         convertedKey: CodingKey,
@@ -71,7 +71,7 @@ internal class _XMLReferencingEncoder: _XMLEncoder {
 
     // MARK: - Coding Path Operations
 
-    internal override var canEncodeNewValue: Bool {
+    override var canEncodeNewValue: Bool {
         // With a regular encoder, the storage and coding path grow together.
         // A referencing encoder, however, inherits its parents coding path, as well as the key it was created for.
         // We have to take this into account.

--- a/Sources/XMLCoder/Encoder/XMLUnkeyedEncodingContainer.swift
+++ b/Sources/XMLCoder/Encoder/XMLUnkeyedEncodingContainer.swift
@@ -7,7 +7,7 @@
 
 import Foundation
 
-internal struct _XMLUnkeyedEncodingContainer : UnkeyedEncodingContainer {
+struct _XMLUnkeyedEncodingContainer : UnkeyedEncodingContainer {
     // MARK: Properties
     
     /// A reference to the encoder we're writing to.
@@ -27,7 +27,7 @@ internal struct _XMLUnkeyedEncodingContainer : UnkeyedEncodingContainer {
     // MARK: - Initialization
     
     /// Initializes `self` with the given references.
-    internal init(referencing encoder: _XMLEncoder, codingPath: [CodingKey], wrapping container: UnkeyedBox) {
+    init(referencing encoder: _XMLEncoder, codingPath: [CodingKey], wrapping container: UnkeyedBox) {
         self.encoder = encoder
         self.codingPath = codingPath
         self.container = container


### PR DESCRIPTION
As discussed in https://github.com/MaxDesiatov/XMLCoder/pull/19#discussion_r242742101.