### PR TITLE
Apply SwiftFormat on CI runs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,8 +6,10 @@ env:
 before_install:
 - gem install cocoapods --pre # Since Travis is not always on latest version
 - brew update
+- brew install swiftformat
 - brew outdated carthage || brew upgrade carthage
 script:
+- swiftformat --lint --verbose .
 - pod lib lint
 - xcodebuild test -enableCodeCoverage YES -scheme XMLCoder
 before_deploy:

--- a/Sources/XMLCoder/Auxiliaries/String+Extensions.swift
+++ b/Sources/XMLCoder/Auxiliaries/String+Extensions.swift
@@ -10,11 +10,11 @@ import Foundation
 extension String {
     func escape(_ characterSet: [(character: String, escapedCharacter: String)]) -> String {
         var string = self
-        
+
         for set in characterSet {
             string = string.replacingOccurrences(of: set.character, with: set.escapedCharacter, options: .literal)
         }
-        
+
         return string
     }
 }

--- a/Sources/XMLCoder/Auxiliaries/XMLElement.swift
+++ b/Sources/XMLCoder/Auxiliaries/XMLElement.swift
@@ -10,31 +10,31 @@ import Foundation
 struct _XMLElement {
     static let attributesKey = "___ATTRIBUTES"
     static let escapedCharacterSet = [("&", "&amp"), ("<", "&lt;"), (">", "&gt;"), ("'", "&apos;"), ("\"", "&quot;")]
-    
+
     var key: String
     var value: String?
     var attributes: [String: String] = [:]
     var elements: [String: [_XMLElement]] = [:]
-    
+
     init(key: String, value: String? = nil, attributes: [String: String] = [:], elements: [String: [_XMLElement]] = [:]) {
         self.key = key
         self.value = value
         self.attributes = attributes
         self.elements = elements
     }
-    
+
     init(key: String, box: UnkeyedBox) {
         self.init(key: key)
-        
-        self.elements[key] = box.map { box in
+
+        elements[key] = box.map { box in
             _XMLElement(key: key, box: box)
         }
     }
-    
+
     init(key: String, box: KeyedBox) {
         self.init(key: key)
-        
-        self.attributes = Dictionary(uniqueKeysWithValues: box.attributes.compactMap { key, box in
+
+        attributes = Dictionary(uniqueKeysWithValues: box.attributes.compactMap { key, box in
             guard let value = box.xmlString() else {
                 return nil
             }
@@ -57,17 +57,17 @@ struct _XMLElement {
                 preconditionFailure("Unclassified box: \(type(of: box))")
             }
         }
-        
-        self.elements = Dictionary(elementsByKey) { existingElements, newElements in
+
+        elements = Dictionary(elementsByKey) { existingElements, newElements in
             existingElements + newElements
         }
     }
-    
+
     init(key: String, box: SimpleBox) {
         self.init(key: key)
-        self.value = box.xmlString()
+        value = box.xmlString()
     }
-    
+
     init(key: String, box: Box) {
         switch box {
         case let unkeyedBox as UnkeyedBox:
@@ -80,20 +80,20 @@ struct _XMLElement {
             preconditionFailure("Unclassified box: \(type(of: box))")
         }
     }
-    
+
     mutating func append(value string: String) {
         var value = self.value ?? ""
         value += string.trimmingCharacters(in: .whitespacesAndNewlines)
         self.value = value
     }
-    
+
     mutating func append(element: _XMLElement, forKey key: String) {
-        self.elements[key, default: []].append(element)
+        elements[key, default: []].append(element)
     }
-    
+
     func flatten() -> KeyedBox {
         let attributes = self.attributes.mapValues { StringBox($0) }
-        
+
         var elements: [String: Box] = [:]
         for (key, value) in self.elements {
             for child in value {
@@ -127,18 +127,18 @@ struct _XMLElement {
 
         return KeyedBox(elements: elements, attributes: attributes)
     }
-    
+
     func toXMLString(with header: XMLHeader? = nil, withCDATA cdata: Bool, formatting: XMLEncoder.OutputFormatting, ignoreEscaping _: Bool = false) -> String {
         if let header = header, let headerXML = header.toXML() {
             return headerXML + _toXMLString(withCDATA: cdata, formatting: formatting)
         }
         return _toXMLString(withCDATA: cdata, formatting: formatting)
     }
-    
+
     fileprivate func formatUnsortedXMLElements(_ string: inout String, _ level: Int, _ cdata: Bool, _ formatting: XMLEncoder.OutputFormatting, _ prettyPrinted: Bool) {
         formatXMLElements(from: elements.map { (key: $0, value: $1) }, into: &string, at: level, cdata: cdata, formatting: formatting, prettyPrinted: prettyPrinted)
     }
-    
+
     fileprivate func elementString(for element: (key: String, value: [_XMLElement]), at level: Int, cdata: Bool, formatting: XMLEncoder.OutputFormatting, prettyPrinted: Bool) -> String {
         var string = ""
         for child in element.value {
@@ -147,35 +147,35 @@ struct _XMLElement {
         }
         return string
     }
-    
+
     fileprivate func formatSortedXMLElements(_ string: inout String, _ level: Int, _ cdata: Bool, _ formatting: XMLEncoder.OutputFormatting, _ prettyPrinted: Bool) {
         formatXMLElements(from: elements.sorted { $0.key < $1.key }, into: &string, at: level, cdata: cdata, formatting: formatting, prettyPrinted: prettyPrinted)
     }
-    
+
     fileprivate func attributeString(key: String, value: String) -> String {
         return " \(key)=\"\(value.escape(_XMLElement.escapedCharacterSet))\""
     }
-    
+
     fileprivate func formatXMLAttributes(from keyValuePairs: [(key: String, value: String)], into string: inout String) {
         for (key, value) in keyValuePairs {
             string += attributeString(key: key, value: value)
         }
     }
-    
+
     fileprivate func formatXMLElements(from elements: [(key: String, value: [_XMLElement])], into string: inout String, at level: Int, cdata: Bool, formatting: XMLEncoder.OutputFormatting, prettyPrinted: Bool) {
         for element in elements {
             string += elementString(for: element, at: level, cdata: cdata, formatting: formatting, prettyPrinted: prettyPrinted)
         }
     }
-    
+
     fileprivate func formatSortedXMLAttributes(_ string: inout String) {
         formatXMLAttributes(from: attributes.sorted(by: { $0.key < $1.key }), into: &string)
     }
-    
+
     fileprivate func formatUnsortedXMLAttributes(_ string: inout String) {
         formatXMLAttributes(from: attributes.map { (key: $0, value: $1) }, into: &string)
     }
-    
+
     fileprivate func formatXMLAttributes(_ formatting: XMLEncoder.OutputFormatting, _ string: inout String) {
         if #available(macOS 10.13, iOS 11.0, watchOS 4.0, tvOS 11.0, *) {
             if formatting.contains(.sortedKeys) {
@@ -187,7 +187,7 @@ struct _XMLElement {
         }
         formatUnsortedXMLAttributes(&string)
     }
-    
+
     fileprivate func formatXMLElements(_ formatting: XMLEncoder.OutputFormatting, _ string: inout String, _ level: Int, _ cdata: Bool, _ prettyPrinted: Bool) {
         if #available(macOS 10.13, iOS 11.0, watchOS 4.0, tvOS 11.0, *) {
             if formatting.contains(.sortedKeys) {
@@ -199,15 +199,15 @@ struct _XMLElement {
         }
         formatUnsortedXMLElements(&string, level, cdata, formatting, prettyPrinted)
     }
-    
+
     fileprivate func _toXMLString(indented level: Int = 0, withCDATA cdata: Bool, formatting: XMLEncoder.OutputFormatting, ignoreEscaping: Bool = false) -> String {
         let prettyPrinted = formatting.contains(.prettyPrinted)
         let indentation = String(repeating: " ", count: (prettyPrinted ? level : 0) * 4)
         var string = indentation
         string += "<\(key)"
-        
+
         formatXMLAttributes(formatting, &string)
-        
+
         if let value = value {
             string += ">"
             if !ignoreEscaping {
@@ -219,13 +219,13 @@ struct _XMLElement {
         } else if !elements.isEmpty {
             string += prettyPrinted ? ">\n" : ">"
             formatXMLElements(formatting, &string, level, cdata, prettyPrinted)
-            
+
             string += indentation
             string += "</\(key)>"
         } else {
             string += " />"
         }
-        
+
         return string
     }
 }
@@ -237,8 +237,8 @@ extension _XMLElement: Equatable {
             lhs.value == rhs.value,
             lhs.attributes == rhs.attributes,
             lhs.elements == rhs.elements
-            else {
-                return false
+        else {
+            return false
         }
         return true
     }

--- a/Sources/XMLCoder/Auxiliaries/XMLHeader.swift
+++ b/Sources/XMLCoder/Auxiliaries/XMLHeader.swift
@@ -14,34 +14,34 @@ public struct XMLHeader {
     public let encoding: String?
     /// indicates whether a document relies on information from an external source.
     public let standalone: String?
-    
+
     public init(version: Double? = nil, encoding: String? = nil, standalone: String? = nil) {
         self.version = version
         self.encoding = encoding
         self.standalone = standalone
     }
-    
+
     func isEmpty() -> Bool {
         return version == nil && encoding == nil && standalone == nil
     }
-    
+
     func toXML() -> String? {
         guard !isEmpty() else { return nil }
-        
+
         var string = "<?xml "
-        
+
         if let version = version {
             string += "version=\"\(version)\" "
         }
-        
+
         if let encoding = encoding {
             string += "encoding=\"\(encoding)\" "
         }
-        
+
         if let standalone = standalone {
             string += "standalone=\"\(standalone)\""
         }
-        
+
         return string.trimmingCharacters(in: .whitespaces) + "?>\n"
     }
 }

--- a/Sources/XMLCoder/Auxiliaries/XMLStackParser.swift
+++ b/Sources/XMLCoder/Auxiliaries/XMLStackParser.swift
@@ -8,12 +8,10 @@
 
 import Foundation
 
-struct XMLElementContext {
-    
-}
+struct XMLElementContext {}
 
 class _XMLStackParser: NSObject {
-    var root: _XMLElement? = nil
+    var root: _XMLElement?
     private var stack: [_XMLElement] = []
 
     static func parse(with data: Data) throws -> KeyedBox {
@@ -25,25 +23,25 @@ class _XMLStackParser: NSObject {
                 debugDescription: "The given data could not be parsed into XML."
             ))
         }
-        
+
         return node.flatten()
     }
 
     func parse(with data: Data) throws -> _XMLElement? {
         let xmlParser = XMLParser(data: data)
         xmlParser.delegate = self
-        
+
         guard xmlParser.parse() else {
             if let error = xmlParser.parserError {
                 throw error
             }
             return nil
         }
-        
+
         return root
     }
-    
-    func withCurrentElement(_ body: (inout _XMLElement) throws -> ()) rethrows {
+
+    func withCurrentElement(_ body: (inout _XMLElement) throws -> Void) rethrows {
         guard !stack.isEmpty else {
             return
         }
@@ -66,11 +64,11 @@ extension _XMLStackParser: XMLParserDelegate {
         guard var element = stack.popLast() else {
             return
         }
-        
+
         if let value = element.value {
             element.value = value.isEmpty ? nil : value
         }
-        
+
         withCurrentElement { currentElement in
             currentElement.append(element: element, forKey: element.key)
         }

--- a/Sources/XMLCoder/Box/BoolBox.swift
+++ b/Sources/XMLCoder/Box/BoolBox.swift
@@ -9,13 +9,13 @@ import Foundation
 
 struct BoolBox: Equatable {
     typealias Unboxed = Bool
-    
+
     let unboxed: Unboxed
-    
+
     init(_ unboxed: Unboxed) {
         self.unboxed = unboxed
     }
-    
+
     init?(xmlString: String) {
         switch xmlString {
         case "false", "0": self.init(false)
@@ -23,9 +23,9 @@ struct BoolBox: Equatable {
         case _: return nil
         }
     }
-    
+
     func unbox() -> Unboxed {
-        return self.unboxed
+        return unboxed
     }
 }
 
@@ -33,7 +33,7 @@ extension BoolBox: Box {
     var isNull: Bool {
         return false
     }
-    
+
     /// # Lexical representation
     /// Boolean has a lexical representation consisting of the following
     /// legal literals {`true`, `false`, `1`, `0`}.
@@ -45,16 +45,14 @@ extension BoolBox: Box {
     ///
     /// [Schema definition](https://www.w3.org/TR/xmlschema-2/#boolean)
     func xmlString() -> String? {
-        return (self.unboxed) ? "true" : "false"
+        return (unboxed) ? "true" : "false"
     }
 }
 
-extension BoolBox: SimpleBox {
-    
-}
+extension BoolBox: SimpleBox {}
 
 extension BoolBox: CustomStringConvertible {
     var description: String {
-        return self.unboxed.description
+        return unboxed.description
     }
 }

--- a/Sources/XMLCoder/Box/Box.swift
+++ b/Sources/XMLCoder/Box/Box.swift
@@ -13,6 +13,4 @@ protocol Box {
 }
 
 /// A box that only describes a single atomic value.
-protocol SimpleBox: Box {
-    
-}
+protocol SimpleBox: Box {}

--- a/Sources/XMLCoder/Box/DataBox.swift
+++ b/Sources/XMLCoder/Box/DataBox.swift
@@ -11,32 +11,32 @@ struct DataBox: Equatable {
     enum Format: Equatable {
         case base64
     }
-    
+
     typealias Unboxed = Data
-    
+
     let unboxed: Unboxed
     let format: Format
-    
+
     init(_ unboxed: Unboxed, format: Format) {
         self.unboxed = unboxed
         self.format = format
     }
-    
+
     init?(base64 string: String) {
         guard let data = Data(base64Encoded: string) else {
             return nil
         }
         self.init(data, format: .base64)
     }
-    
+
     func unbox() -> Unboxed {
-        return self.unboxed
+        return unboxed
     }
-    
+
     func xmlString(format: Format) -> String {
         switch format {
         case .base64:
-            return self.unboxed.base64EncodedString()
+            return unboxed.base64EncodedString()
         }
     }
 }
@@ -45,18 +45,16 @@ extension DataBox: Box {
     var isNull: Bool {
         return false
     }
-    
+
     func xmlString() -> String? {
-        return self.xmlString(format: self.format)
+        return xmlString(format: format)
     }
 }
 
-extension DataBox: SimpleBox {
-    
-}
+extension DataBox: SimpleBox {}
 
 extension DataBox: CustomStringConvertible {
     var description: String {
-        return self.unboxed.description
+        return unboxed.description
     }
 }

--- a/Sources/XMLCoder/Box/DateBox.swift
+++ b/Sources/XMLCoder/Box/DateBox.swift
@@ -14,17 +14,17 @@ struct DateBox: Equatable {
         case iso8601
         case formatter(DateFormatter)
     }
-    
+
     typealias Unboxed = Date
-    
+
     let unboxed: Unboxed
     let format: Format
-    
+
     init(_ unboxed: Unboxed, format: Format) {
         self.unboxed = unboxed
         self.format = format
     }
-    
+
     init?(secondsSince1970 string: String) {
         guard let seconds = TimeInterval(string) else {
             return nil
@@ -32,7 +32,7 @@ struct DateBox: Equatable {
         let unboxed = Date(timeIntervalSince1970: seconds)
         self.init(unboxed, format: .secondsSince1970)
     }
-    
+
     init?(millisecondsSince1970 string: String) {
         guard let milliseconds = TimeInterval(string) else {
             return nil
@@ -40,7 +40,7 @@ struct DateBox: Equatable {
         let unboxed = Date(timeIntervalSince1970: milliseconds / 1000.0)
         self.init(unboxed, format: .millisecondsSince1970)
     }
-    
+
     init?(iso8601 string: String) {
         if #available(macOS 10.12, iOS 10.0, watchOS 3.0, tvOS 10.0, *) {
             guard let unboxed = _iso8601Formatter.date(from: string) else {
@@ -51,25 +51,25 @@ struct DateBox: Equatable {
             fatalError("ISO8601DateFormatter is unavailable on this platform.")
         }
     }
-    
+
     init?(xmlString: String, formatter: DateFormatter) {
         guard let date = formatter.date(from: xmlString) else {
             return nil
         }
         self.init(date, format: .formatter(formatter))
     }
-    
+
     func unbox() -> Unboxed {
-        return self.unboxed
+        return unboxed
     }
-    
+
     func xmlString(format: Format) -> String {
         switch format {
         case .secondsSince1970:
-            let seconds = self.unboxed.timeIntervalSince1970
+            let seconds = unboxed.timeIntervalSince1970
             return seconds.description
         case .millisecondsSince1970:
-            let milliseconds = self.unboxed.timeIntervalSince1970 * 1000.0
+            let milliseconds = unboxed.timeIntervalSince1970 * 1000.0
             return milliseconds.description
         case .iso8601:
             if #available(macOS 10.12, iOS 10.0, watchOS 3.0, tvOS 10.0, *) {
@@ -77,8 +77,8 @@ struct DateBox: Equatable {
             } else {
                 fatalError("ISO8601DateFormatter is unavailable on this platform.")
             }
-        case .formatter(let formatter):
-            return formatter.string(from: self.unboxed)
+        case let .formatter(formatter):
+            return formatter.string(from: unboxed)
         }
     }
 }
@@ -87,18 +87,16 @@ extension DateBox: Box {
     var isNull: Bool {
         return false
     }
-    
+
     func xmlString() -> String? {
-        return self.xmlString(format: self.format)
+        return xmlString(format: format)
     }
 }
 
-extension DateBox: SimpleBox {
-    
-}
+extension DateBox: SimpleBox {}
 
 extension DateBox: CustomStringConvertible {
     var description: String {
-        return self.unboxed.description
+        return unboxed.description
     }
 }

--- a/Sources/XMLCoder/Box/DecimalBox.swift
+++ b/Sources/XMLCoder/Box/DecimalBox.swift
@@ -9,22 +9,22 @@ import Foundation
 
 struct DecimalBox: Equatable {
     typealias Unboxed = Decimal
-    
+
     let unboxed: Unboxed
-    
+
     init(_ unboxed: Unboxed) {
         self.unboxed = unboxed
     }
-    
+
     init?(xmlString: String) {
         guard let unboxed = Unboxed(string: xmlString) else {
             return nil
         }
         self.init(unboxed)
     }
-    
+
     func unbox() -> Unboxed {
-        return self.unboxed
+        return unboxed
     }
 }
 
@@ -32,7 +32,7 @@ extension DecimalBox: Box {
     var isNull: Bool {
         return false
     }
-    
+
     /// # Lexical representation
     /// Decimal has a lexical representation consisting of a finite-length sequence of
     /// decimal digits separated by a period as a decimal indicator.
@@ -52,16 +52,14 @@ extension DecimalBox: Box {
     ///
     /// [Schema definition](https://www.w3.org/TR/xmlschema-2/#decimal)
     func xmlString() -> String? {
-        return "\(self.unboxed)"
+        return "\(unboxed)"
     }
 }
 
-extension DecimalBox: SimpleBox {
-    
-}
+extension DecimalBox: SimpleBox {}
 
 extension DecimalBox: CustomStringConvertible {
     var description: String {
-        return self.unboxed.description
+        return unboxed.description
     }
 }

--- a/Sources/XMLCoder/Box/FloatBox.swift
+++ b/Sources/XMLCoder/Box/FloatBox.swift
@@ -9,22 +9,22 @@ import Foundation
 
 struct FloatBox: Equatable {
     typealias Unboxed = Float64
-    
+
     let unboxed: Unboxed
-    
+
     init<Float: BinaryFloatingPoint>(_ unboxed: Float) {
         self.unboxed = Unboxed(unboxed)
     }
-    
+
     init?(xmlString: String) {
         guard let unboxed = Unboxed(xmlString) else {
             return nil
         }
         self.init(unboxed)
     }
-    
+
     func unbox<Float: BinaryFloatingPoint>() -> Float? {
-        return Float(exactly: self.unboxed)
+        return Float(exactly: unboxed)
     }
 }
 
@@ -32,7 +32,7 @@ extension FloatBox: Box {
     var isNull: Bool {
         return false
     }
-    
+
     /// # Lexical representation
     /// float values have a lexical representation consisting of a mantissa followed, optionally,
     /// by the character `"E"` or `"e"`, followed by an exponent. The exponent **must** be an integer.
@@ -62,24 +62,22 @@ extension FloatBox: Box {
     ///
     /// [Schema definition](https://www.w3.org/TR/xmlschema-2/#float)
     func xmlString() -> String? {
-        guard !self.unboxed.isNaN else {
+        guard !unboxed.isNaN else {
             return "NaN"
         }
-        
-        guard !self.unboxed.isInfinite else {
-            return (self.unboxed > 0.0) ? "INF" : "-INF"
+
+        guard !unboxed.isInfinite else {
+            return (unboxed > 0.0) ? "INF" : "-INF"
         }
-        
-        return self.unboxed.description
+
+        return unboxed.description
     }
 }
 
-extension FloatBox: SimpleBox {
-    
-}
+extension FloatBox: SimpleBox {}
 
 extension FloatBox: CustomStringConvertible {
     var description: String {
-        return self.unboxed.description
+        return unboxed.description
     }
 }

--- a/Sources/XMLCoder/Box/IntBox.swift
+++ b/Sources/XMLCoder/Box/IntBox.swift
@@ -9,22 +9,22 @@ import Foundation
 
 struct IntBox: Equatable {
     typealias Unboxed = Int64
-    
+
     let unboxed: Unboxed
-    
+
     init<Integer: SignedInteger>(_ unboxed: Integer) {
         self.unboxed = Unboxed(unboxed)
     }
-    
+
     init?(xmlString: String) {
         guard let unboxed = Unboxed(xmlString) else {
             return nil
         }
         self.init(unboxed)
     }
-    
+
     func unbox<Integer: BinaryInteger>() -> Integer? {
-        return Integer(exactly: self.unboxed)
+        return Integer(exactly: unboxed)
     }
 }
 
@@ -32,7 +32,7 @@ extension IntBox: Box {
     var isNull: Bool {
         return false
     }
-    
+
     /// # Lexical representation
     /// Integer has a lexical representation consisting of a finite-length sequence of
     /// decimal digits with an optional leading sign. If the sign is omitted, `"+"` is assumed.
@@ -47,16 +47,14 @@ extension IntBox: Box {
     ///
     /// [Schema definition](https://www.w3.org/TR/xmlschema-2/#integer)
     func xmlString() -> String? {
-        return self.unboxed.description
+        return unboxed.description
     }
 }
 
-extension IntBox: SimpleBox {
-    
-}
+extension IntBox: SimpleBox {}
 
 extension IntBox: CustomStringConvertible {
     var description: String {
-        return self.unboxed.description
+        return unboxed.description
     }
 }

--- a/Sources/XMLCoder/Box/KeyedBox.swift
+++ b/Sources/XMLCoder/Box/KeyedBox.swift
@@ -9,60 +9,60 @@ import Foundation
 
 struct KeyedStorage<Key: Hashable, Value> {
     typealias Buffer = [Key: Value]
-    
+
     fileprivate var buffer: Buffer = [:]
-    
+
     var count: Int {
-        return self.buffer.count
+        return buffer.count
     }
-    
+
     var keys: Buffer.Keys {
-        return self.buffer.keys
+        return buffer.keys
     }
-    
+
     init(_ buffer: Buffer) {
         self.buffer = buffer
     }
-    
+
     subscript(key: Key) -> Value? {
         get {
-            return self.buffer[key]
+            return buffer[key]
         }
         set {
-            self.buffer[key] = newValue
+            buffer[key] = newValue
         }
     }
-    
+
     func filter(_ isIncluded: (Key, Value) throws -> Bool) rethrows -> [(Key, Value)] {
-        return try self.buffer.filter(isIncluded)
+        return try buffer.filter(isIncluded)
     }
-    
+
     func map<T>(_ transform: (Key, Value) throws -> T) rethrows -> [T] {
-        return try self.buffer.map(transform)
+        return try buffer.map(transform)
     }
-    
+
     func compactMap<T>(_ transform: ((Key, Value)) throws -> T?) rethrows -> [T] {
-        return try self.buffer.compactMap(transform)
+        return try buffer.compactMap(transform)
     }
-    
+
     func mapValues<T>(_ transform: (Value) throws -> T) rethrows -> [Key: T] {
-        return try self.buffer.mapValues(transform)
+        return try buffer.mapValues(transform)
     }
-    
+
     func mapValues<T>(_ transform: (Value) throws -> T) rethrows -> [(Key, T)] {
-        return Array(try self.mapValues(transform))
+        return Array(try mapValues(transform))
     }
-    
+
     func mapValues(_ transform: (Value) throws -> Value) rethrows -> KeyedStorage {
-        return KeyedStorage(try self.mapValues(transform))
+        return KeyedStorage(try mapValues(transform))
     }
 }
 
 extension KeyedStorage: Sequence {
     typealias Iterator = Buffer.Iterator
-    
+
     func makeIterator() -> Iterator {
-        return self.buffer.makeIterator()
+        return buffer.makeIterator()
     }
 }
 
@@ -79,31 +79,30 @@ class KeyedBox {
 
     typealias Attributes = KeyedStorage<Key, Attribute>
     typealias Elements = KeyedStorage<Key, Element>
-    
+
     var attributes: Attributes = [:]
     var elements: Elements = [:]
-    
+
     init() {
-        self.attributes = [:]
-        self.elements = [:]
+        attributes = [:]
+        elements = [:]
     }
-    
+
     init<E, A>(elements: E, attributes: A)
-        where E: Sequence, E.Element == (Key, Element), A: Sequence, A.Element == (Key, Attribute)
-    {
+        where E: Sequence, E.Element == (Key, Element), A: Sequence, A.Element == (Key, Attribute) {
         self.elements = Elements(Dictionary(uniqueKeysWithValues: elements))
         self.attributes = Attributes(Dictionary(uniqueKeysWithValues: attributes))
     }
-    
+
     init(elements: [Key: Element], attributes: [Key: Attribute]) {
         self.elements = Elements(elements)
         self.attributes = Attributes(attributes)
     }
-    
+
     func unbox() -> (elements: Elements, attributes: Attributes) {
         return (
-            elements: self.elements,
-            attributes: self.attributes
+            elements: elements,
+            attributes: attributes
         )
     }
 }
@@ -112,7 +111,7 @@ extension KeyedBox: Box {
     var isNull: Bool {
         return false
     }
-    
+
     func xmlString() -> String? {
         return nil
     }

--- a/Sources/XMLCoder/Box/NullBox.swift
+++ b/Sources/XMLCoder/Box/NullBox.swift
@@ -15,18 +15,16 @@ extension NullBox: Box {
     var isNull: Bool {
         return true
     }
-    
+
     func xmlString() -> String? {
         return nil
     }
 }
 
-extension NullBox: SimpleBox {
-    
-}
+extension NullBox: SimpleBox {}
 
 extension NullBox: Equatable {
-    static func == (lhs: NullBox, rhs: NullBox) -> Bool {
+    static func == (_: NullBox, _: NullBox) -> Bool {
         return true
     }
 }

--- a/Sources/XMLCoder/Box/StringBox.swift
+++ b/Sources/XMLCoder/Box/StringBox.swift
@@ -9,19 +9,19 @@ import Foundation
 
 struct StringBox: Equatable {
     typealias Unboxed = String
-    
+
     let unboxed: Unboxed
-    
+
     init(_ unboxed: Unboxed) {
         self.unboxed = unboxed
     }
-    
+
     init(xmlString: Unboxed) {
         self.init(xmlString)
     }
-    
+
     func unbox() -> Unboxed {
-        return self.unboxed
+        return unboxed
     }
 }
 
@@ -29,18 +29,16 @@ extension StringBox: Box {
     var isNull: Bool {
         return false
     }
-    
+
     func xmlString() -> String? {
-        return self.unboxed.description
+        return unboxed.description
     }
 }
 
-extension StringBox: SimpleBox {
-    
-}
+extension StringBox: SimpleBox {}
 
 extension StringBox: CustomStringConvertible {
     var description: String {
-        return self.unboxed.description
+        return unboxed.description
     }
 }

--- a/Sources/XMLCoder/Box/UIntBox.swift
+++ b/Sources/XMLCoder/Box/UIntBox.swift
@@ -9,22 +9,22 @@ import Foundation
 
 struct UIntBox: Equatable {
     typealias Unboxed = UInt64
-    
+
     let unboxed: Unboxed
-    
+
     init<Integer: UnsignedInteger>(_ unboxed: Integer) {
         self.unboxed = Unboxed(unboxed)
     }
-    
+
     init?(xmlString: String) {
         guard let unboxed = Unboxed(xmlString) else {
             return nil
         }
         self.init(unboxed)
     }
-    
+
     func unbox<Integer: BinaryInteger>() -> Integer? {
-        return Integer(exactly: self.unboxed)
+        return Integer(exactly: unboxed)
     }
 }
 
@@ -32,7 +32,7 @@ extension UIntBox: Box {
     var isNull: Bool {
         return false
     }
-    
+
     /// # Lexical representation
     /// Unsigned integer has a lexical representation consisting of an optional
     /// sign followed by a finite-length sequence of decimal digits.
@@ -50,16 +50,14 @@ extension UIntBox: Box {
     ///
     /// [Schema definition](https://www.w3.org/TR/xmlschema-2/#nonNegativeInteger)
     func xmlString() -> String? {
-        return self.unboxed.description
+        return unboxed.description
     }
 }
 
-extension UIntBox: SimpleBox {
-    
-}
+extension UIntBox: SimpleBox {}
 
 extension UIntBox: CustomStringConvertible {
     var description: String {
-        return self.unboxed.description
+        return unboxed.description
     }
 }

--- a/Sources/XMLCoder/Box/URLBox.swift
+++ b/Sources/XMLCoder/Box/URLBox.swift
@@ -9,22 +9,22 @@ import Foundation
 
 struct URLBox: Equatable {
     typealias Unboxed = URL
-    
+
     let unboxed: Unboxed
-    
+
     init(_ unboxed: Unboxed) {
         self.unboxed = unboxed
     }
-    
+
     init?(xmlString: String) {
         guard let unboxed = Unboxed(string: xmlString) else {
             return nil
         }
         self.init(unboxed)
     }
-    
+
     func unbox() -> Unboxed {
-        return self.unboxed
+        return unboxed
     }
 }
 
@@ -34,16 +34,14 @@ extension URLBox: Box {
     }
 
     func xmlString() -> String? {
-        return self.unboxed.absoluteString
+        return unboxed.absoluteString
     }
 }
 
-extension URLBox: SimpleBox {
-    
-}
+extension URLBox: SimpleBox {}
 
 extension URLBox: CustomStringConvertible {
     var description: String {
-        return self.unboxed.description
+        return unboxed.description
     }
 }

--- a/Sources/XMLCoder/Box/UnkeyedBox.swift
+++ b/Sources/XMLCoder/Box/UnkeyedBox.swift
@@ -11,48 +11,48 @@ import Foundation
 class UnkeyedBox {
     typealias Element = Box
     typealias Unboxed = [Element]
-    
+
     private(set) var unboxed: Unboxed
-    
+
     var count: Int {
-        return self.unboxed.count
+        return unboxed.count
     }
-    
+
     subscript(index: Int) -> Element {
         get {
-            return self.unboxed[index]
+            return unboxed[index]
         }
         set {
-            self.unboxed[index] = newValue
+            unboxed[index] = newValue
         }
     }
-    
+
     init(_ unboxed: Unboxed = []) {
         self.unboxed = unboxed
     }
-    
+
     func unbox() -> Unboxed {
-        return self.unboxed
+        return unboxed
     }
-    
+
     func append(_ newElement: Element) {
-        self.unboxed.append(newElement)
+        unboxed.append(newElement)
     }
-    
+
     func insert(_ newElement: Element, at index: Int) {
-        self.unboxed.insert(newElement, at: index)
+        unboxed.insert(newElement, at: index)
     }
-    
+
     func filter(_ isIncluded: (Element) throws -> Bool) rethrows -> [Element] {
-        return try self.unboxed.filter(isIncluded)
+        return try unboxed.filter(isIncluded)
     }
-    
+
     func map<T>(_ transform: (Element) throws -> T) rethrows -> [T] {
-        return try self.unboxed.map(transform)
+        return try unboxed.map(transform)
     }
-    
+
     func compactMap<T>(_ transform: (Element) throws -> T?) rethrows -> [T] {
-        return try self.unboxed.compactMap(transform)
+        return try unboxed.compactMap(transform)
     }
 }
 
@@ -60,7 +60,7 @@ extension UnkeyedBox: Box {
     var isNull: Bool {
         return false
     }
-    
+
     func xmlString() -> String? {
         return nil
     }
@@ -68,14 +68,14 @@ extension UnkeyedBox: Box {
 
 extension UnkeyedBox: Sequence {
     typealias Iterator = Unboxed.Iterator
-    
+
     func makeIterator() -> Iterator {
-        return self.unboxed.makeIterator()
+        return unboxed.makeIterator()
     }
 }
 
 extension UnkeyedBox: CustomStringConvertible {
     var description: String {
-        return self.unboxed.description
+        return unboxed.description
     }
 }

--- a/Sources/XMLCoder/Decoder/XMLDecoder.swift
+++ b/Sources/XMLCoder/Decoder/XMLDecoder.swift
@@ -160,7 +160,7 @@ open class XMLDecoder {
 
             // Find the last non-underscore character
             var lastNonUnderscore = stringKey.index(before: stringKey.endIndex)
-            while lastNonUnderscore > firstNonUnderscore && stringKey[lastNonUnderscore] == "_" {
+            while lastNonUnderscore > firstNonUnderscore, stringKey[lastNonUnderscore] == "_" {
                 stringKey.formIndex(before: &lastNonUnderscore)
             }
 
@@ -179,9 +179,9 @@ open class XMLDecoder {
 
             // Do a cheap isEmpty check before creating and appending potentially empty strings
             let result: String
-            if leadingUnderscoreRange.isEmpty && trailingUnderscoreRange.isEmpty {
+            if leadingUnderscoreRange.isEmpty, trailingUnderscoreRange.isEmpty {
                 result = joinedString
-            } else if !leadingUnderscoreRange.isEmpty && !trailingUnderscoreRange.isEmpty {
+            } else if !leadingUnderscoreRange.isEmpty, !trailingUnderscoreRange.isEmpty {
                 // Both leading and trailing underscores
                 result = String(stringKey[leadingUnderscoreRange]) + joinedString + String(stringKey[trailingUnderscoreRange])
             } else if !leadingUnderscoreRange.isEmpty {
@@ -351,7 +351,7 @@ extension _XMLDecoder: SingleValueDecodingContainer {
         try expectNonNull(Bool.self)
         return try unbox(storage.topContainer)!
     }
-    
+
     public func decode(_: Decimal.Type) throws -> Decimal {
         try expectNonNull(Decimal.self)
         return try unbox(storage.topContainer)!
@@ -361,27 +361,27 @@ extension _XMLDecoder: SingleValueDecodingContainer {
         try expectNonNull(T.self)
         return try unbox(storage.topContainer)!
     }
-    
+
     public func decode<T: BinaryInteger & UnsignedInteger & Decodable>(_: T.Type) throws -> T {
         try expectNonNull(T.self)
         return try unbox(storage.topContainer)!
     }
-    
+
     public func decode<T: BinaryFloatingPoint & Decodable>(_: T.Type) throws -> T {
         try expectNonNull(T.self)
         return try unbox(storage.topContainer)!
     }
-    
+
     public func decode(_: String.Type) throws -> String {
         try expectNonNull(String.self)
         return try unbox(storage.topContainer)!
     }
-    
+
     public func decode(_: String.Type) throws -> Date {
         try expectNonNull(String.self)
         return try unbox(storage.topContainer)!
     }
-    
+
     public func decode(_: String.Type) throws -> Data {
         try expectNonNull(String.self)
         return try unbox(storage.topContainer)!
@@ -397,85 +397,85 @@ extension _XMLDecoder: SingleValueDecodingContainer {
 
 extension _XMLDecoder {
     /// Returns the given box unboxed from a container.
-    
+
     func unbox(_ box: Box) throws -> Bool? {
         guard !box.isNull else { return nil }
-        
+
         guard let string = (box as? StringBox)?.unbox() else { return nil }
-        
+
         guard let boolBox = BoolBox(xmlString: string) else {
             throw DecodingError._typeMismatch(at: codingPath, expectation: Bool.self, reality: box)
         }
-        
+
         return boolBox.unbox()
     }
-    
+
     func unbox(_ box: Box) throws -> Decimal? {
         guard !box.isNull else { return nil }
-        
+
         guard let string = (box as? StringBox)?.unbox() else { return nil }
-        
+
         guard let decimalBox = DecimalBox(xmlString: string) else {
             throw DecodingError._typeMismatch(at: codingPath, expectation: Decimal.self, reality: box)
         }
-        
+
         return decimalBox.unbox()
     }
 
     func unbox<T: BinaryInteger & SignedInteger & Decodable>(_ box: Box) throws -> T? {
         guard !box.isNull else { return nil }
-        
+
         guard let string = (box as? StringBox)?.unbox() else { return nil }
-        
+
         guard let intBox = IntBox(xmlString: string) else {
             throw DecodingError._typeMismatch(at: codingPath, expectation: T.self, reality: box)
         }
-        
+
         guard let int: T = intBox.unbox() else {
             throw DecodingError.dataCorrupted(DecodingError.Context(
                 codingPath: codingPath,
                 debugDescription: "Parsed XML number <\(string)> does not fit in \(T.self)."
             ))
         }
-        
+
         return int
     }
-    
+
     func unbox<T: BinaryInteger & UnsignedInteger & Decodable>(_ box: Box) throws -> T? {
         guard !box.isNull else { return nil }
-        
+
         guard let string = (box as? StringBox)?.unbox() else { return nil }
-        
+
         guard let uintBox = UIntBox(xmlString: string) else {
             throw DecodingError._typeMismatch(at: codingPath, expectation: T.self, reality: box)
         }
-        
+
         guard let uint: T = uintBox.unbox() else {
             throw DecodingError.dataCorrupted(DecodingError.Context(
                 codingPath: codingPath,
                 debugDescription: "Parsed XML number <\(string)> does not fit in \(T.self)."
             ))
         }
-        
+
         return uint
     }
 
     func unbox<T: BinaryFloatingPoint & Decodable>(_ box: Box) throws -> T? {
         guard !box.isNull else { return nil }
-        
+
         guard let string = (box as? StringBox)?.unbox() else { return nil }
-        
+
         guard let floatBox = FloatBox(xmlString: string) else {
             throw DecodingError._typeMismatch(at: codingPath, expectation: T.self, reality: box)
         }
-        
+
         guard let float: T = floatBox.unbox() else {
             throw DecodingError.dataCorrupted(DecodingError.Context(
                 codingPath: codingPath,
                 debugDescription: "Parsed XML number <\(string)> does not fit in \(T.self)."
             ))
         }
-        
+
         return float
     }
 
@@ -568,26 +568,26 @@ extension _XMLDecoder {
                     debugDescription: "Encountered Data is not valid Base64"
                 ))
             }
-            return dataBox.unbox()            
+            return dataBox.unbox()
         case let .custom(closure):
             storage.push(container: box)
             defer { storage.popContainer() }
             return try closure(self)
         }
     }
-    
+
     func unbox(_ box: Box) throws -> URL? {
         guard !box.isNull else { return nil }
-        
+
         guard let string = (box as? StringBox)?.unbox() else { return nil }
-        
+
         guard let urlBox = URLBox(xmlString: string) else {
             throw DecodingError.dataCorrupted(DecodingError.Context(
                 codingPath: codingPath,
                 debugDescription: "Encountered Data is not valid Base64"
             ))
         }
-        
+
         return urlBox.unbox()
     }
 

--- a/Sources/XMLCoder/Decoder/XMLKeyedDecodingContainer.swift
+++ b/Sources/XMLCoder/Decoder/XMLKeyedDecodingContainer.swift
@@ -113,118 +113,118 @@ struct _XMLKeyedDecodingContainer<K: CodingKey>: KeyedDecodingContainerProtocol 
     }
 
     public func decode(_ type: Bool.Type, forKey key: Key) throws -> Bool {
-        return try self.decode(type, forKey: key) { decoder, box in
-            return try decoder.unbox(box)
+        return try decode(type, forKey: key) { decoder, box in
+            try decoder.unbox(box)
         }
     }
 
     public func decode(_ type: Decimal.Type, forKey key: Key) throws -> Decimal {
-        return try self.decode(type, forKey: key) { decoder, box in
-            return try decoder.unbox(box)
+        return try decode(type, forKey: key) { decoder, box in
+            try decoder.unbox(box)
         }
     }
 
     public func decode(_ type: Int.Type, forKey key: Key) throws -> Int {
-        return try self.decodeSignedInteger(type, forKey: key)
+        return try decodeSignedInteger(type, forKey: key)
     }
 
     public func decode(_ type: Int8.Type, forKey key: Key) throws -> Int8 {
-        return try self.decodeSignedInteger(type, forKey: key)
+        return try decodeSignedInteger(type, forKey: key)
     }
 
     public func decode(_ type: Int16.Type, forKey key: Key) throws -> Int16 {
-        return try self.decodeSignedInteger(type, forKey: key)
+        return try decodeSignedInteger(type, forKey: key)
     }
 
     public func decode(_ type: Int32.Type, forKey key: Key) throws -> Int32 {
-        return try self.decodeSignedInteger(type, forKey: key)
+        return try decodeSignedInteger(type, forKey: key)
     }
 
     public func decode(_ type: Int64.Type, forKey key: Key) throws -> Int64 {
-        return try self.decodeSignedInteger(type, forKey: key)
+        return try decodeSignedInteger(type, forKey: key)
     }
 
     public func decode(_ type: UInt.Type, forKey key: Key) throws -> UInt {
-        return try self.decodeUnsignedInteger(type, forKey: key)
+        return try decodeUnsignedInteger(type, forKey: key)
     }
 
     public func decode(_ type: UInt8.Type, forKey key: Key) throws -> UInt8 {
-        return try self.decodeUnsignedInteger(type, forKey: key)
+        return try decodeUnsignedInteger(type, forKey: key)
     }
 
     public func decode(_ type: UInt16.Type, forKey key: Key) throws -> UInt16 {
-        return try self.decodeUnsignedInteger(type, forKey: key)
+        return try decodeUnsignedInteger(type, forKey: key)
     }
 
     public func decode(_ type: UInt32.Type, forKey key: Key) throws -> UInt32 {
-        return try self.decodeUnsignedInteger(type, forKey: key)
+        return try decodeUnsignedInteger(type, forKey: key)
     }
 
     public func decode(_ type: UInt64.Type, forKey key: Key) throws -> UInt64 {
-        return try self.decodeUnsignedInteger(type, forKey: key)
+        return try decodeUnsignedInteger(type, forKey: key)
     }
 
     public func decode(_ type: Float.Type, forKey key: Key) throws -> Float {
-        return try self.decodeFloatingPoint(type, forKey: key)
+        return try decodeFloatingPoint(type, forKey: key)
     }
 
     public func decode(_ type: Double.Type, forKey key: Key) throws -> Double {
-        return try self.decodeFloatingPoint(type, forKey: key)
+        return try decodeFloatingPoint(type, forKey: key)
     }
 
     public func decode(_ type: String.Type, forKey key: Key) throws -> String {
-        return try self.decode(type, forKey: key) { decoder, box in
-            return try decoder.unbox(box)
+        return try decode(type, forKey: key) { decoder, box in
+            try decoder.unbox(box)
         }
     }
 
     public func decode(_ type: Date.Type, forKey key: Key) throws -> Date {
-        return try self.decode(type, forKey: key) { decoder, box in
-            return try decoder.unbox(box)
+        return try decode(type, forKey: key) { decoder, box in
+            try decoder.unbox(box)
         }
     }
 
     public func decode(_ type: Data.Type, forKey key: Key) throws -> Data {
-        return try self.decode(type, forKey: key) { decoder, box in
-            return try decoder.unbox(box)
+        return try decode(type, forKey: key) { decoder, box in
+            try decoder.unbox(box)
         }
     }
 
     public func decode<T: Decodable>(_ type: T.Type, forKey key: Key) throws -> T {
         let attributeNotFound = (container.attributes[key.stringValue] == nil)
         let elementNotFound = (container.elements[key.stringValue] == nil)
-        
-        if type is AnyEmptySequence.Type && attributeNotFound && elementNotFound {
+
+        if type is AnyEmptySequence.Type, attributeNotFound, elementNotFound {
             return (type as! AnyEmptySequence.Type).init() as! T
         }
 
-        return try self.decode(type, forKey: key) { decoder, box in
-            return try decoder.unbox(box)
+        return try decode(type, forKey: key) { decoder, box in
+            try decoder.unbox(box)
         }
     }
 
     private func decodeSignedInteger<T: BinaryInteger & SignedInteger & Decodable>(_ type: T.Type, forKey key: Key) throws -> T {
-        return try self.decode(type, forKey: key) { decoder, box in
-            return try decoder.unbox(box)
+        return try decode(type, forKey: key) { decoder, box in
+            try decoder.unbox(box)
         }
     }
 
     private func decodeUnsignedInteger<T: BinaryInteger & UnsignedInteger & Decodable>(_ type: T.Type, forKey key: Key) throws -> T {
-        return try self.decode(type, forKey: key) { decoder, box in
-            return try decoder.unbox(box)
+        return try decode(type, forKey: key) { decoder, box in
+            try decoder.unbox(box)
         }
     }
 
     private func decodeFloatingPoint<T: BinaryFloatingPoint & Decodable>(_ type: T.Type, forKey key: Key) throws -> T {
-        return try self.decode(type, forKey: key) { decoder, box in
-            return try decoder.unbox(box)
+        return try decode(type, forKey: key) { decoder, box in
+            try decoder.unbox(box)
         }
     }
 
     private func decode<T: Decodable>(
         _ type: T.Type,
         forKey key: Key,
-        decode: (_XMLDecoder, Box) throws -> T?
+        decode _: (_XMLDecoder, Box) throws -> T?
     ) throws -> T {
         guard let entry = container.elements[key.stringValue] ?? container.attributes[key.stringValue] else {
             throw DecodingError.keyNotFound(key, DecodingError.Context(

--- a/Sources/XMLCoder/Decoder/XMLUnkeyedDecodingContainer.swift
+++ b/Sources/XMLCoder/Decoder/XMLUnkeyedDecodingContainer.swift
@@ -60,89 +60,89 @@ struct _XMLUnkeyedDecodingContainer: UnkeyedDecodingContainer {
     }
 
     public mutating func decode(_ type: Bool.Type) throws -> Bool {
-        return try self.decode(type) { decoder, box in
-            return try decoder.unbox(box)
+        return try decode(type) { decoder, box in
+            try decoder.unbox(box)
         }
     }
 
     public mutating func decode(_ type: Int.Type) throws -> Int {
-        return try self.decodeSignedInteger(type)
+        return try decodeSignedInteger(type)
     }
 
     public mutating func decode(_ type: Int8.Type) throws -> Int8 {
-        return try self.decodeSignedInteger(type)
+        return try decodeSignedInteger(type)
     }
 
     public mutating func decode(_ type: Int16.Type) throws -> Int16 {
-        return try self.decodeSignedInteger(type)
+        return try decodeSignedInteger(type)
     }
 
     public mutating func decode(_ type: Int32.Type) throws -> Int32 {
-        return try self.decodeSignedInteger(type)
+        return try decodeSignedInteger(type)
     }
 
     public mutating func decode(_ type: Int64.Type) throws -> Int64 {
-        return try self.decodeSignedInteger(type)
+        return try decodeSignedInteger(type)
     }
-    
+
     public mutating func decode(_ type: UInt.Type) throws -> UInt {
-        return try self.decodeUnsignedInteger(type)
+        return try decodeUnsignedInteger(type)
     }
 
     public mutating func decode(_ type: UInt8.Type) throws -> UInt8 {
-        return try self.decodeUnsignedInteger(type)
+        return try decodeUnsignedInteger(type)
     }
 
     public mutating func decode(_ type: UInt16.Type) throws -> UInt16 {
-        return try self.decodeUnsignedInteger(type)
+        return try decodeUnsignedInteger(type)
     }
 
     public mutating func decode(_ type: UInt32.Type) throws -> UInt32 {
-        return try self.decodeUnsignedInteger(type)
+        return try decodeUnsignedInteger(type)
     }
 
     public mutating func decode(_ type: UInt64.Type) throws -> UInt64 {
-        return try self.decodeUnsignedInteger(type)
+        return try decodeUnsignedInteger(type)
     }
-    
+
     public mutating func decode(_ type: Float.Type) throws -> Float {
-        return try self.decodeFloatingPoint(type)
+        return try decodeFloatingPoint(type)
     }
 
     public mutating func decode(_ type: Double.Type) throws -> Double {
-        return try self.decodeFloatingPoint(type)
+        return try decodeFloatingPoint(type)
     }
 
     public mutating func decode(_ type: String.Type) throws -> String {
-        return try self.decode(type) { decoder, box in
-            return try decoder.unbox(box)
+        return try decode(type) { decoder, box in
+            try decoder.unbox(box)
         }
     }
 
     public mutating func decode<T: Decodable>(_ type: T.Type) throws -> T {
-        return try self.decode(type) { decoder, box in
-            return try decoder.unbox(box)
+        return try decode(type) { decoder, box in
+            try decoder.unbox(box)
         }
     }
-    
+
     private mutating func decodeSignedInteger<T: BinaryInteger & SignedInteger & Decodable>(_ type: T.Type) throws -> T {
-        return try self.decode(type) { decoder, box in
-            return try decoder.unbox(box)
+        return try decode(type) { decoder, box in
+            try decoder.unbox(box)
         }
     }
-    
+
     private mutating func decodeUnsignedInteger<T: BinaryInteger & UnsignedInteger & Decodable>(_ type: T.Type) throws -> T {
-        return try self.decode(type) { decoder, box in
-            return try decoder.unbox(box)
+        return try decode(type) { decoder, box in
+            try decoder.unbox(box)
         }
     }
-    
+
     private mutating func decodeFloatingPoint<T: BinaryFloatingPoint & Decodable>(_ type: T.Type) throws -> T {
-        return try self.decode(type) { decoder, box in
-            return try decoder.unbox(box)
+        return try decode(type) { decoder, box in
+            try decoder.unbox(box)
         }
     }
-    
+
     private mutating func decode<T: Decodable>(
         _ type: T.Type,
         decode: (_XMLDecoder, Box) throws -> T?
@@ -153,11 +153,11 @@ struct _XMLUnkeyedDecodingContainer: UnkeyedDecodingContainer {
                 debugDescription: "Unkeyed container is at end."
             ))
         }
-        
+
         decoder.codingPath.append(_XMLKey(index: currentIndex))
         defer { self.decoder.codingPath.removeLast() }
-        
-        let box = self.container[self.currentIndex]
+
+        let box = container[self.currentIndex]
         let value = try decode(decoder, box)
         guard let decoded: T = value else {
             throw DecodingError.valueNotFound(type, DecodingError.Context(
@@ -165,7 +165,7 @@ struct _XMLUnkeyedDecodingContainer: UnkeyedDecodingContainer {
                 debugDescription: "Expected \(type) but found null instead."
             ))
         }
-        
+
         currentIndex += 1
         return decoded
     }

--- a/Sources/XMLCoder/Encoder/XMLEncoder.swift
+++ b/Sources/XMLCoder/Encoder/XMLEncoder.swift
@@ -381,7 +381,7 @@ extension _XMLEncoder: SingleValueEncodingContainer {
     // MARK: - SingleValueEncodingContainer Methods
 
     func assertCanEncodeNewValue() {
-        precondition(self.canEncodeNewValue, "Attempt to encode value through single value container when previously value already encoded.")
+        precondition(canEncodeNewValue, "Attempt to encode value through single value container when previously value already encoded.")
     }
 
     public func encodeNil() throws {

--- a/Sources/XMLCoder/Encoder/XMLKeyedEncodingContainer.swift
+++ b/Sources/XMLCoder/Encoder/XMLKeyedEncodingContainer.swift
@@ -7,31 +7,31 @@
 
 import Foundation
 
-struct _XMLKeyedEncodingContainer<K : CodingKey> : KeyedEncodingContainerProtocol {
+struct _XMLKeyedEncodingContainer<K: CodingKey>: KeyedEncodingContainerProtocol {
     typealias Key = K
-    
+
     // MARK: Properties
-    
+
     /// A reference to the encoder we're writing to.
     private let encoder: _XMLEncoder
-    
+
     /// A reference to the container we're writing to.
     private let container: KeyedBox
-    
+
     /// The path of coding keys taken to get to this point in encoding.
-    private(set) public var codingPath: [CodingKey]
-    
+    public private(set) var codingPath: [CodingKey]
+
     // MARK: - Initialization
-    
+
     /// Initializes `self` with the given references.
     init(referencing encoder: _XMLEncoder, codingPath: [CodingKey], wrapping container: KeyedBox) {
         self.encoder = encoder
         self.codingPath = codingPath
         self.container = container
     }
-    
+
     // MARK: - Coding Path Operations
-    
+
     private func _converted(_ key: CodingKey) -> CodingKey {
         switch encoder.options.keyEncodingStrategy {
         case .useDefaultKeys:
@@ -39,138 +39,138 @@ struct _XMLKeyedEncodingContainer<K : CodingKey> : KeyedEncodingContainerProtoco
         case .convertToSnakeCase:
             let newKeyString = XMLEncoder.KeyEncodingStrategy._convertToSnakeCase(key.stringValue)
             return _XMLKey(stringValue: newKeyString, intValue: key.intValue)
-        case .custom(let converter):
+        case let .custom(converter):
             return converter(codingPath + [key])
         }
     }
-    
+
     // MARK: - KeyedEncodingContainerProtocol Methods
-    
+
     public mutating func encodeNil(forKey key: Key) throws {
-        self.container.elements[_converted(key).stringValue] = NullBox()
+        container.elements[_converted(key).stringValue] = NullBox()
     }
-    
+
     public mutating func encode(_ value: Bool, forKey key: Key) throws {
-        return try self.encode(value, forKey: key) { encoder, value in
-            return encoder.box(value)
+        return try encode(value, forKey: key) { encoder, value in
+            encoder.box(value)
         }
     }
-    
+
     public mutating func encode(_ value: Decimal, forKey key: Key) throws {
-        return try self.encode(value, forKey: key) { encoder, value in
-            return encoder.box(value)
+        return try encode(value, forKey: key) { encoder, value in
+            encoder.box(value)
         }
     }
-    
+
     public mutating func encode(_ value: Int, forKey key: Key) throws {
-        return try self.encodeSignedInteger(value, forKey: key)
+        return try encodeSignedInteger(value, forKey: key)
     }
-    
+
     public mutating func encode(_ value: Int8, forKey key: Key) throws {
-        return try self.encodeSignedInteger(value, forKey: key)
+        return try encodeSignedInteger(value, forKey: key)
     }
-    
+
     public mutating func encode(_ value: Int16, forKey key: Key) throws {
-        return try self.encodeSignedInteger(value, forKey: key)
+        return try encodeSignedInteger(value, forKey: key)
     }
-    
+
     public mutating func encode(_ value: Int32, forKey key: Key) throws {
-        return try self.encodeSignedInteger(value, forKey: key)
+        return try encodeSignedInteger(value, forKey: key)
     }
-    
+
     public mutating func encode(_ value: Int64, forKey key: Key) throws {
-        return try self.encodeSignedInteger(value, forKey: key)
+        return try encodeSignedInteger(value, forKey: key)
     }
-    
+
     public mutating func encode(_ value: UInt, forKey key: Key) throws {
-        return try self.encodeUnsignedInteger(value, forKey: key)
+        return try encodeUnsignedInteger(value, forKey: key)
     }
-    
+
     public mutating func encode(_ value: UInt8, forKey key: Key) throws {
-        return try self.encodeUnsignedInteger(value, forKey: key)
+        return try encodeUnsignedInteger(value, forKey: key)
     }
-    
+
     public mutating func encode(_ value: UInt16, forKey key: Key) throws {
-        return try self.encodeUnsignedInteger(value, forKey: key)
+        return try encodeUnsignedInteger(value, forKey: key)
     }
-    
+
     public mutating func encode(_ value: UInt32, forKey key: Key) throws {
-        return try self.encodeUnsignedInteger(value, forKey: key)
+        return try encodeUnsignedInteger(value, forKey: key)
     }
-    
+
     public mutating func encode(_ value: UInt64, forKey key: Key) throws {
-        return try self.encodeUnsignedInteger(value, forKey: key)
+        return try encodeUnsignedInteger(value, forKey: key)
     }
-    
+
     public mutating func encode(_ value: Float, forKey key: Key) throws {
-        return try self.encodeFloatingPoint(value, forKey: key)
+        return try encodeFloatingPoint(value, forKey: key)
     }
-    
+
     public mutating func encode(_ value: Double, forKey key: Key) throws {
-        return try self.encodeFloatingPoint(value, forKey: key)
+        return try encodeFloatingPoint(value, forKey: key)
     }
-    
+
     public mutating func encode(_ value: String, forKey key: Key) throws {
-        return try self.encode(value, forKey: key) { encoder, value in
-            return encoder.box(value)
+        return try encode(value, forKey: key) { encoder, value in
+            encoder.box(value)
         }
     }
-    
+
     public mutating func encode(_ value: Date, forKey key: Key) throws {
-        return try self.encode(value, forKey: key) { encoder, value in
-            return try encoder.box(value)
+        return try encode(value, forKey: key) { encoder, value in
+            try encoder.box(value)
         }
     }
-    
+
     public mutating func encode(_ value: Data, forKey key: Key) throws {
-        return try self.encode(value, forKey: key) { encoder, value in
-            return try encoder.box(value)
+        return try encode(value, forKey: key) { encoder, value in
+            try encoder.box(value)
         }
     }
-    
+
     public mutating func encode<T: Encodable>(_ value: T, forKey key: Key) throws {
-        return try self.encode(value, forKey: key) { encoder, value in
-            return try encoder.box(value)
+        return try encode(value, forKey: key) { encoder, value in
+            try encoder.box(value)
         }
     }
-    
+
     private mutating func encodeSignedInteger<T: BinaryInteger & SignedInteger & Encodable>(_ value: T, forKey key: Key) throws {
-        return try self.encode(value, forKey: key) { encoder, value in
-            return encoder.box(value)
+        return try encode(value, forKey: key) { encoder, value in
+            encoder.box(value)
         }
     }
-    
+
     private mutating func encodeUnsignedInteger<T: BinaryInteger & UnsignedInteger & Encodable>(_ value: T, forKey key: Key) throws {
-        return try self.encode(value, forKey: key) { encoder, value in
-            return encoder.box(value)
+        return try encode(value, forKey: key) { encoder, value in
+            encoder.box(value)
         }
     }
-    
+
     private mutating func encodeFloatingPoint<T: BinaryFloatingPoint & Encodable>(_ value: T, forKey key: Key) throws {
-        return try self.encode(value, forKey: key) { encoder, value in
-            return try encoder.box(value)
+        return try encode(value, forKey: key) { encoder, value in
+            try encoder.box(value)
         }
     }
-    
+
     private mutating func encode<T: Encodable>(
         _ value: T,
         forKey key: Key,
         encode: (_XMLEncoder, T) throws -> Box
     ) throws {
         defer {
-            let _ = self.encoder.nodeEncodings.removeLast()
+            _ = self.encoder.nodeEncodings.removeLast()
             self.encoder.codingPath.removeLast()
         }
         guard let strategy = self.encoder.nodeEncodings.last else {
             preconditionFailure("Attempt to access node encoding strategy from empty stack.")
         }
-        self.encoder.codingPath.append(key)
-        let nodeEncodings = self.encoder.options.nodeEncodingStrategy.nodeEncodings(
+        encoder.codingPath.append(key)
+        let nodeEncodings = encoder.options.nodeEncodingStrategy.nodeEncodings(
             forType: T.self,
-            with: self.encoder
+            with: encoder
         )
-        self.encoder.nodeEncodings.append(nodeEncodings)
-        let box = try encode(self.encoder, value)
+        encoder.nodeEncodings.append(nodeEncodings)
+        let box = try encode(encoder, value)
         switch strategy(key) {
         case .attribute:
             guard let attribute = box as? SimpleBox else {
@@ -179,37 +179,37 @@ struct _XMLKeyedEncodingContainer<K : CodingKey> : KeyedEncodingContainerProtoco
                     debugDescription: "Complex values cannot be encoded as attributes."
                 ))
             }
-            self.container.attributes[_converted(key).stringValue] = attribute
+            container.attributes[_converted(key).stringValue] = attribute
         case .element:
-            self.container.elements[_converted(key).stringValue] = box
+            container.elements[_converted(key).stringValue] = box
         }
     }
-    
-    public mutating func nestedContainer<NestedKey>(keyedBy keyType: NestedKey.Type, forKey key: Key) -> KeyedEncodingContainer<NestedKey> {
+
+    public mutating func nestedContainer<NestedKey>(keyedBy _: NestedKey.Type, forKey key: Key) -> KeyedEncodingContainer<NestedKey> {
         let keyed = KeyedBox()
         self.container.elements[_converted(key).stringValue] = keyed
-        
-        self.codingPath.append(key)
+
+        codingPath.append(key)
         defer { self.codingPath.removeLast() }
-        
-        let container = _XMLKeyedEncodingContainer<NestedKey>(referencing: self.encoder, codingPath: self.codingPath, wrapping: keyed)
+
+        let container = _XMLKeyedEncodingContainer<NestedKey>(referencing: encoder, codingPath: codingPath, wrapping: keyed)
         return KeyedEncodingContainer(container)
     }
-    
+
     public mutating func nestedUnkeyedContainer(forKey key: Key) -> UnkeyedEncodingContainer {
         let unkeyed = UnkeyedBox()
-        self.container.elements[_converted(key).stringValue] = unkeyed
-        
-        self.codingPath.append(key)
+        container.elements[_converted(key).stringValue] = unkeyed
+
+        codingPath.append(key)
         defer { self.codingPath.removeLast() }
-        return _XMLUnkeyedEncodingContainer(referencing: self.encoder, codingPath: self.codingPath, wrapping: unkeyed)
+        return _XMLUnkeyedEncodingContainer(referencing: encoder, codingPath: codingPath, wrapping: unkeyed)
     }
-    
+
     public mutating func superEncoder() -> Encoder {
-        return _XMLReferencingEncoder(referencing: self.encoder, key: _XMLKey.super, convertedKey: _converted(_XMLKey.super), wrapping: self.container)
+        return _XMLReferencingEncoder(referencing: encoder, key: _XMLKey.super, convertedKey: _converted(_XMLKey.super), wrapping: container)
     }
-    
+
     public mutating func superEncoder(forKey key: Key) -> Encoder {
-        return _XMLReferencingEncoder(referencing: self.encoder, key: key, convertedKey: _converted(key), wrapping: self.container)
+        return _XMLReferencingEncoder(referencing: encoder, key: key, convertedKey: _converted(key), wrapping: container)
     }
 }

--- a/Sources/XMLCoder/Encoder/XMLUnkeyedEncodingContainer.swift
+++ b/Sources/XMLCoder/Encoder/XMLUnkeyedEncodingContainer.swift
@@ -7,171 +7,171 @@
 
 import Foundation
 
-struct _XMLUnkeyedEncodingContainer : UnkeyedEncodingContainer {
+struct _XMLUnkeyedEncodingContainer: UnkeyedEncodingContainer {
     // MARK: Properties
-    
+
     /// A reference to the encoder we're writing to.
     private let encoder: _XMLEncoder
-    
+
     /// A reference to the container we're writing to.
     private let container: UnkeyedBox
-    
+
     /// The path of coding keys taken to get to this point in encoding.
-    private(set) public var codingPath: [CodingKey]
-    
+    public private(set) var codingPath: [CodingKey]
+
     /// The number of elements encoded into the container.
     public var count: Int {
-        return self.container.count
+        return container.count
     }
-    
+
     // MARK: - Initialization
-    
+
     /// Initializes `self` with the given references.
     init(referencing encoder: _XMLEncoder, codingPath: [CodingKey], wrapping container: UnkeyedBox) {
         self.encoder = encoder
         self.codingPath = codingPath
         self.container = container
     }
-    
+
     // MARK: - UnkeyedEncodingContainer Methods
-    
+
     public mutating func encodeNil() throws {
-        self.container.append(self.encoder.box())
+        container.append(encoder.box())
     }
-    
+
     public mutating func encode(_ value: Bool) throws {
-        self.encode(value) { encoder, value in
-            return encoder.box(value)
+        encode(value) { encoder, value in
+            encoder.box(value)
         }
     }
-    
+
     public mutating func encode(_ value: Decimal) throws {
-        self.encode(value) { encoder, value in
-            return encoder.box(value)
+        encode(value) { encoder, value in
+            encoder.box(value)
         }
     }
-    
+
     public mutating func encode(_ value: Int) throws {
-        try self.encodeSignedInteger(value)
+        try encodeSignedInteger(value)
     }
-    
+
     public mutating func encode(_ value: Int8) throws {
-        try self.encodeSignedInteger(value)
+        try encodeSignedInteger(value)
     }
-    
+
     public mutating func encode(_ value: Int16) throws {
-        try self.encodeSignedInteger(value)
+        try encodeSignedInteger(value)
     }
-    
+
     public mutating func encode(_ value: Int32) throws {
-        try self.encodeSignedInteger(value)
+        try encodeSignedInteger(value)
     }
-    
+
     public mutating func encode(_ value: Int64) throws {
-        try self.encodeSignedInteger(value)
+        try encodeSignedInteger(value)
     }
 
     public mutating func encode(_ value: UInt) throws {
-        try self.encodeUnsignedInteger(value)
+        try encodeUnsignedInteger(value)
     }
-    
+
     public mutating func encode(_ value: UInt8) throws {
-        try self.encodeUnsignedInteger(value)
+        try encodeUnsignedInteger(value)
     }
-    
+
     public mutating func encode(_ value: UInt16) throws {
-        try self.encodeUnsignedInteger(value)
+        try encodeUnsignedInteger(value)
     }
-    
+
     public mutating func encode(_ value: UInt32) throws {
-        try self.encodeUnsignedInteger(value)
+        try encodeUnsignedInteger(value)
     }
-    
+
     public mutating func encode(_ value: UInt64) throws {
-        try self.encodeUnsignedInteger(value)
+        try encodeUnsignedInteger(value)
     }
-    
+
     public mutating func encode(_ value: Float) throws {
-        try self.encodeFloatingPoint(value)
+        try encodeFloatingPoint(value)
     }
-    
+
     public mutating func encode(_ value: Double) throws {
-        try self.encodeFloatingPoint(value)
+        try encodeFloatingPoint(value)
     }
-    
+
     public mutating func encode(_ value: String) throws {
-        self.encode(value) { encoder, value in
-            return encoder.box(value)
+        encode(value) { encoder, value in
+            encoder.box(value)
         }
     }
-    
+
     public mutating func encode(_ value: Date) throws {
-        try self.encode(value) { encoder, value in
+        try encode(value) { encoder, value in
             return try encoder.box(value)
         }
     }
-    
+
     public mutating func encode(_ value: Data) throws {
-        try self.encode(value) { encoder, value in
+        try encode(value) { encoder, value in
             return try encoder.box(value)
         }
     }
-    
+
     private mutating func encodeSignedInteger<T: BinaryInteger & SignedInteger & Encodable>(_ value: T) throws {
-        self.encode(value) { encoder, value in
-            return encoder.box(value)
+        encode(value) { encoder, value in
+            encoder.box(value)
         }
     }
-    
+
     private mutating func encodeUnsignedInteger<T: BinaryInteger & UnsignedInteger & Encodable>(_ value: T) throws {
-        self.encode(value) { encoder, value in
-            return encoder.box(value)
+        encode(value) { encoder, value in
+            encoder.box(value)
         }
     }
-    
-    private mutating func encodeFloatingPoint<T: BinaryFloatingPoint & Encodable>(_ value: T)  throws {
-        try self.encode(value) { encoder, value in
+
+    private mutating func encodeFloatingPoint<T: BinaryFloatingPoint & Encodable>(_ value: T) throws {
+        try encode(value) { encoder, value in
             return try encoder.box(value)
         }
     }
-    
+
     public mutating func encode<T: Encodable>(_ value: T) throws {
-        try self.encode(value) { encoder, value in
+        try encode(value) { encoder, value in
             return try encoder.box(value)
         }
     }
-    
+
     private mutating func encode<T: Encodable>(
         _ value: T,
-        encode: (_XMLEncoder, T) throws -> (Box)
+        encode: (_XMLEncoder, T) throws -> Box
     ) rethrows {
-        self.encoder.codingPath.append(_XMLKey(index: self.count))
+        encoder.codingPath.append(_XMLKey(index: count))
         defer { self.encoder.codingPath.removeLast() }
-        self.container.append(try encode(self.encoder, value))
+        container.append(try encode(encoder, value))
     }
-    
-    public mutating func nestedContainer<NestedKey>(keyedBy keyType: NestedKey.Type) -> KeyedEncodingContainer<NestedKey> {
-        self.codingPath.append(_XMLKey(index: self.count))
+
+    public mutating func nestedContainer<NestedKey>(keyedBy _: NestedKey.Type) -> KeyedEncodingContainer<NestedKey> {
+        codingPath.append(_XMLKey(index: count))
         defer { self.codingPath.removeLast() }
-        
+
         let keyed = KeyedBox()
         self.container.append(keyed)
-        
-        let container = _XMLKeyedEncodingContainer<NestedKey>(referencing: self.encoder, codingPath: self.codingPath, wrapping: keyed)
+
+        let container = _XMLKeyedEncodingContainer<NestedKey>(referencing: encoder, codingPath: codingPath, wrapping: keyed)
         return KeyedEncodingContainer(container)
     }
-    
+
     public mutating func nestedUnkeyedContainer() -> UnkeyedEncodingContainer {
-        self.codingPath.append(_XMLKey(index: self.count))
+        codingPath.append(_XMLKey(index: count))
         defer { self.codingPath.removeLast() }
-        
+
         let unkeyed = UnkeyedBox()
-        self.container.append(unkeyed)
-        
-        return _XMLUnkeyedEncodingContainer(referencing: self.encoder, codingPath: self.codingPath, wrapping: unkeyed)
+        container.append(unkeyed)
+
+        return _XMLUnkeyedEncodingContainer(referencing: encoder, codingPath: codingPath, wrapping: unkeyed)
     }
-    
+
     public mutating func superEncoder() -> Encoder {
-        return _XMLReferencingEncoder(referencing: self.encoder, at: self.container.count, wrapping: self.container)
+        return _XMLReferencingEncoder(referencing: encoder, at: container.count, wrapping: container)
     }
 }

--- a/Tests/XMLCoderTests/Auxiliary/XMLStackParserTests.swift
+++ b/Tests/XMLCoderTests/Auxiliary/XMLStackParserTests.swift
@@ -11,12 +11,12 @@ import XCTest
 class XMLStackParserTests: XCTestCase {
     func testParseWith() throws {
         let parser = _XMLStackParser()
-        
+
         let xmlString = "<container><value>42</value></container>"
         let xmlData = xmlString.data(using: .utf8)!
-        
+
         let root: _XMLElement? = try parser.parse(with: xmlData)
-        
+
         let expected = _XMLElement(
             key: "container",
             elements: [
@@ -24,8 +24,8 @@ class XMLStackParserTests: XCTestCase {
                     _XMLElement(
                         key: "value",
                         value: "42"
-                    )
-                ]
+                    ),
+                ],
             ]
         )
         XCTAssertEqual(root, expected)

--- a/Tests/XMLCoderTests/BooksTest.swift
+++ b/Tests/XMLCoderTests/BooksTest.swift
@@ -149,7 +149,7 @@ private let catalogXML = """
 
 private struct Catalog: Codable, Equatable {
     var books: [Book]
-    
+
     enum CodingKeys: String, CodingKey {
         case books = "book"
     }
@@ -163,10 +163,10 @@ private struct Book: Codable, Equatable {
     var price: Double
     var publishDate: Date
     var description: String
-    
+
     enum CodingKeys: String, CodingKey {
         case id, author, title, genre, price, description
-        
+
         case publishDate = "publish_date"
     }
 }
@@ -197,7 +197,7 @@ final class BooksTest: XCTestCase {
         do {
             let book1 = try decoder.decode(Book.self, from: bookXML)
             XCTAssertEqual(book1.publishDate,
-                           Date(timeIntervalSince1970: 970358400))
+                           Date(timeIntervalSince1970: 970_358_400))
 
             let data = try encoder.encode(book1, withRootKey: "book",
                                           header: XMLHeader(version: 1.0,
@@ -220,7 +220,7 @@ final class BooksTest: XCTestCase {
             let catalog1 = try decoder.decode(Catalog.self, from: catalogXML)
             XCTAssertEqual(catalog1.books.count, 12)
             XCTAssertEqual(catalog1.books[0].publishDate,
-                           Date(timeIntervalSince1970: 970358400))
+                           Date(timeIntervalSince1970: 970_358_400))
 
             let data = try encoder.encode(catalog1, withRootKey: "catalog",
                                           header: XMLHeader(version: 1.0,
@@ -235,5 +235,4 @@ final class BooksTest: XCTestCase {
     static var allTests = [
         ("testBookXML", testBookXML),
     ]
-
 }

--- a/Tests/XMLCoderTests/Box/BoolBoxTests.swift
+++ b/Tests/XMLCoderTests/Box/BoolBoxTests.swift
@@ -10,31 +10,31 @@ import XCTest
 
 class BoolBoxTests: XCTestCase {
     typealias Boxed = BoolBox
-    
+
     func testUnbox() {
         let values: [Boxed.Unboxed] = [
             false,
             true,
         ]
-        
+
         for unboxed in values {
             let box = Boxed(unboxed)
             XCTAssertEqual(box.unbox(), unboxed)
         }
     }
-    
+
     func testXMLString() {
         let values: [(Boxed.Unboxed, String)] = [
             (false, "false"),
             (true, "true"),
         ]
-        
+
         for (unboxed, string) in values {
             let box = Boxed(unboxed)
             XCTAssertEqual(box.xmlString(), string)
         }
     }
-    
+
     func testValidValues() {
         let values: [String] = [
             "0",
@@ -42,20 +42,20 @@ class BoolBoxTests: XCTestCase {
             "false",
             "true",
         ]
-        
+
         for string in values {
             let box = Boxed(xmlString: string)
             XCTAssertNotNil(box)
         }
     }
-    
+
     func testInvalidValues() {
         let values: [String] = [
             "42",
             "foobar",
             "",
         ]
-        
+
         for string in values {
             let box = Boxed(xmlString: string)
             XCTAssertNil(box)

--- a/Tests/XMLCoderTests/Box/DataBoxTests.swift
+++ b/Tests/XMLCoderTests/Box/DataBoxTests.swift
@@ -10,21 +10,21 @@ import XCTest
 
 class DataBoxTests: XCTestCase {
     typealias Boxed = DataBox
-    
+
     typealias FromXMLString = (String) -> Boxed?
-    
+
     func testUnbox() {
         let values: [Boxed.Unboxed] = [
             Data(base64Encoded: "bG9yZW0gaXBzdW0=")!,
             Data(),
         ]
-        
+
         for unboxed in values {
             let box = Boxed(unboxed, format: .base64)
             XCTAssertEqual(box.unbox(), unboxed)
         }
     }
-    
+
     func testValidXMLStrings_base64() {
         let xmlStrings = [
             "",
@@ -32,22 +32,22 @@ class DataBoxTests: XCTestCase {
             "ZG9sb3Igc2l0IGFtZXQ=",
             "Y29uc2VjdGV0dXIgYWRpcGlzY2luZyBlbGl0",
         ]
-        
+
         for xmlString in xmlStrings {
             let boxOrNil = DataBox(base64: xmlString)
             XCTAssertNotNil(boxOrNil)
-            
+
             guard let box = boxOrNil else { continue }
-            
+
             XCTAssertEqual(box.xmlString(), xmlString)
         }
     }
-    
+
     func testInvalidXMLStrings_base64() {
         let xmlStrings = [
             "lorem ipsum",
         ]
-        
+
         for xmlString in xmlStrings {
             let box = Boxed(base64: xmlString)
             XCTAssertNil(box)

--- a/Tests/XMLCoderTests/Box/DateBoxTests.swift
+++ b/Tests/XMLCoderTests/Box/DateBoxTests.swift
@@ -10,134 +10,134 @@ import XCTest
 
 class DateBoxTests: XCTestCase {
     typealias Boxed = DateBox
-    
+
     let customFormatter: DateFormatter = {
         let formatter = DateFormatter()
         formatter.dateFormat = "yyyy-MM-dd HH:mm:ss"
         return formatter
     }()
-    
+
     func testUnbox() {
         let values: [Boxed.Unboxed] = [
             Date(timeIntervalSince1970: 0.0),
             Date(timeIntervalSinceReferenceDate: 0.0),
             Date(),
         ]
-        
+
         for unboxed in values {
             let box = Boxed(unboxed, format: .iso8601)
             XCTAssertEqual(box.unbox(), unboxed)
         }
     }
-    
+
     func testValidStrings_secondsSince1970() {
         let xmlStrings = [
             "-1000.0",
             "0.0",
             "1000.0",
         ]
-        
+
         for xmlString in xmlStrings {
             let boxOrNil = Boxed(secondsSince1970: xmlString)
             XCTAssertNotNil(boxOrNil)
-            
+
             guard let box = boxOrNil else { continue }
-            
+
             XCTAssertEqual(box.xmlString(), xmlString)
         }
     }
-    
+
     func testValidStrings_millisecondsSince1970() {
         let xmlStrings = [
             "-1000.0",
             "0.0",
             "1000.0",
         ]
-        
+
         for xmlString in xmlStrings {
             let boxOrNil = Boxed(millisecondsSince1970: xmlString)
             XCTAssertNotNil(boxOrNil)
-            
+
             guard let box = boxOrNil else { continue }
-            
+
             XCTAssertEqual(box.xmlString(), xmlString)
         }
     }
-    
+
     func testValidStrings_iso8601() {
         let xmlStrings = [
             "1970-01-23T01:23:45Z",
         ]
-        
+
         for xmlString in xmlStrings {
             let boxOrNil = Boxed(iso8601: xmlString)
             XCTAssertNotNil(boxOrNil)
-            
+
             guard let box = boxOrNil else { continue }
-            
+
             XCTAssertEqual(box.xmlString(), xmlString)
         }
     }
-    
+
     func testValidStrings_formatter() {
         let xmlStrings = [
             "1970-01-23 01:23:45",
         ]
-        
+
         for xmlString in xmlStrings {
-            let boxOrNil = Boxed(xmlString: xmlString, formatter: self.customFormatter)
+            let boxOrNil = Boxed(xmlString: xmlString, formatter: customFormatter)
             XCTAssertNotNil(boxOrNil)
-            
+
             guard let box = boxOrNil else { continue }
-            
+
             XCTAssertEqual(box.xmlString(), xmlString)
         }
     }
-    
+
     func testInvalidStrings_secondsSince1970() {
         let xmlStrings = [
             "lorem ipsum",
             "",
         ]
-        
+
         for xmlString in xmlStrings {
             let boxOrNil = Boxed(secondsSince1970: xmlString)
             XCTAssertNil(boxOrNil)
         }
     }
-    
+
     func testInvalidStrings_millisecondsSince1970() {
         let xmlStrings = [
             "lorem ipsum",
             "",
         ]
-        
+
         for xmlString in xmlStrings {
             let boxOrNil = Boxed(millisecondsSince1970: xmlString)
             XCTAssertNil(boxOrNil)
         }
     }
-    
+
     func testInvalidStrings_iso8601() {
         let xmlStrings = [
             "lorem ipsum",
             "",
         ]
-        
+
         for xmlString in xmlStrings {
             let boxOrNil = Boxed(iso8601: xmlString)
             XCTAssertNil(boxOrNil)
         }
     }
-    
+
     func testInvalidStrings_formatter() {
         let xmlStrings = [
             "lorem ipsum",
             "",
         ]
-    
+
         for xmlString in xmlStrings {
-            let boxOrNil = Boxed(xmlString: xmlString, formatter: self.customFormatter)
+            let boxOrNil = Boxed(xmlString: xmlString, formatter: customFormatter)
             XCTAssertNil(boxOrNil)
         }
     }

--- a/Tests/XMLCoderTests/Box/DecimalBoxTests.swift
+++ b/Tests/XMLCoderTests/Box/DecimalBoxTests.swift
@@ -10,33 +10,33 @@ import XCTest
 
 class DecimalBoxTests: XCTestCase {
     typealias Boxed = DecimalBox
-    
+
     func testUnbox() {
         let values: [Boxed.Unboxed] = [
             -1.23,
-            12678967.543233,
-            +100000.00,
+            12_678_967.543233,
+            +100_000.00,
             210,
         ]
-        
+
         for unboxed in values {
             let box = Boxed(unboxed)
             XCTAssertEqual(box.unbox(), unboxed)
         }
     }
-    
+
     func testXMLString() {
         let values: [(Boxed.Unboxed, String)] = [
             (12.34, "12.34"),
             (0.0, "0"),
         ]
-        
+
         for (bool, string) in values {
             let box = Boxed(bool)
             XCTAssertEqual(box.xmlString(), string)
         }
     }
-    
+
     func testValidValues() {
         let values: [String] = [
             "-1.23",
@@ -44,19 +44,19 @@ class DecimalBoxTests: XCTestCase {
             "+100000.00",
             "210",
         ]
-        
+
         for string in values {
             let box = Boxed(xmlString: string)
             XCTAssertNotNil(box)
         }
     }
-    
+
     func testInvalidValues() {
         let values: [String] = [
             "foobar",
             "",
         ]
-        
+
         for string in values {
             let box = Boxed(xmlString: string)
             XCTAssertNil(box)

--- a/Tests/XMLCoderTests/Box/FloatBoxTests.swift
+++ b/Tests/XMLCoderTests/Box/FloatBoxTests.swift
@@ -10,24 +10,24 @@ import XCTest
 
 class FloatBoxTests: XCTestCase {
     typealias Boxed = FloatBox
-    
+
     func testUnbox() {
         let values: [Boxed.Unboxed] = [
-            -3E2,
-            4268.22752E11,
+            -3e2,
+            4268.22752e11,
             +24.3e-3,
             12,
             +3.5,
             -.infinity,
             -0,
         ]
-        
+
         for unboxed in values {
             let box = Boxed(unboxed)
             XCTAssertEqual(box.unbox(), unboxed)
         }
     }
-    
+
     func testXMLString() {
         let values: [(Boxed.Unboxed, String)] = [
             (42.0, "42.0"),
@@ -35,13 +35,13 @@ class FloatBoxTests: XCTestCase {
             (-.infinity, "-INF"),
             (.nan, "NaN"),
         ]
-        
+
         for (double, string) in values {
             let box = FloatBox(double)
             XCTAssertEqual(box.xmlString(), string)
         }
     }
-    
+
     func testValidValues() {
         let values: [String] = [
             "-3E2",
@@ -53,13 +53,13 @@ class FloatBoxTests: XCTestCase {
             "-0",
             "NaN",
         ]
-        
+
         for string in values {
             let box = FloatBox(xmlString: string)
             XCTAssertNotNil(box)
         }
     }
-    
+
     func testInvalidValues() {
         let values: [String] = [
             "-3E2.4",
@@ -67,7 +67,7 @@ class FloatBoxTests: XCTestCase {
             "foobar",
             "",
         ]
-        
+
         for string in values {
             let box = FloatBox(xmlString: string)
             XCTAssertNil(box)

--- a/Tests/XMLCoderTests/Box/IntBoxTests.swift
+++ b/Tests/XMLCoderTests/Box/IntBoxTests.swift
@@ -17,26 +17,26 @@ class IntBoxTests: XCTestCase {
             42,
             0,
         ]
-        
+
         for unboxed in values {
             let box = Boxed(unboxed)
             XCTAssertEqual(box.unbox(), unboxed)
         }
     }
-    
+
     func testXMLString() {
         let values: [(Boxed.Unboxed, String)] = [
             (-42, "-42"),
             (42, "42"),
             (0, "0"),
         ]
-        
+
         for (unboxed, string) in values {
             let box = Boxed(unboxed)
             XCTAssertEqual(box.xmlString(), string)
         }
     }
-    
+
     func testValidValues() {
         let values: [String] = [
             "-1",
@@ -44,19 +44,19 @@ class IntBoxTests: XCTestCase {
             "12678967543233",
             "+100000",
         ]
-        
+
         for string in values {
             let box = Boxed(xmlString: string)
             XCTAssertNotNil(box)
         }
     }
-    
+
     func testInvalidValues() {
         let values: [String] = [
             "foobar",
             "",
         ]
-        
+
         for string in values {
             let box = Boxed(xmlString: string)
             XCTAssertNil(box)

--- a/Tests/XMLCoderTests/Box/KeyedBoxTests.swift
+++ b/Tests/XMLCoderTests/Box/KeyedBoxTests.swift
@@ -13,18 +13,18 @@ class KeyedBoxTests: XCTestCase {
         elements: ["foo": StringBox("bar"), "baz": IntBox(42)],
         attributes: ["baz": StringBox("blee")]
     )
-    
+
     func testUnbox() {
         let (elements, attributes) = box.unbox()
-        
+
         XCTAssertEqual(elements.count, 2)
         XCTAssertEqual(elements["foo"] as? StringBox, StringBox("bar"))
         XCTAssertEqual(elements["baz"] as? IntBox, IntBox(42))
-        
+
         XCTAssertEqual(attributes.count, 1)
         XCTAssertEqual(attributes["baz"] as? StringBox, StringBox("blee"))
     }
-    
+
     func testXMLString() {
         XCTAssertEqual(box.xmlString(), nil)
     }

--- a/Tests/XMLCoderTests/Box/NullBoxTests.swift
+++ b/Tests/XMLCoderTests/Box/NullBoxTests.swift
@@ -10,7 +10,7 @@ import XCTest
 
 class NullBoxTests: XCTestCase {
     typealias Boxed = NullBox
-    
+
     func testXMLString() {
         let box = Boxed()
         XCTAssertEqual(box.xmlString(), nil)

--- a/Tests/XMLCoderTests/Box/StringBoxTests.swift
+++ b/Tests/XMLCoderTests/Box/StringBoxTests.swift
@@ -10,7 +10,7 @@ import XCTest
 
 class StringBoxTests: XCTestCase {
     typealias Boxed = StringBox
-    
+
     func testUnbox() {
         let values: [Boxed.Unboxed] = [
             "",
@@ -19,13 +19,13 @@ class StringBoxTests: XCTestCase {
             "12.34",
             "lorem ipsum",
         ]
-        
+
         for unboxed in values {
             let box = Boxed(unboxed)
             XCTAssertEqual(box.unbox(), unboxed)
         }
     }
-    
+
     func testXMLString() {
         let values: [(Boxed.Unboxed, String)] = [
             ("", ""),
@@ -34,13 +34,13 @@ class StringBoxTests: XCTestCase {
             ("12.34", "12.34"),
             ("lorem ipsum", "lorem ipsum"),
         ]
-        
+
         for (unboxed, string) in values {
             let box = Boxed(unboxed)
             XCTAssertEqual(box.xmlString(), string)
         }
     }
-    
+
     func testValidValues() {
         let values: [String] = [
             "0",
@@ -48,18 +48,18 @@ class StringBoxTests: XCTestCase {
             "false",
             "true",
         ]
-        
+
         for string in values {
             let box = Boxed(xmlString: string)
             XCTAssertNotNil(box)
         }
     }
-    
+
     func testInvalidValues() {
         let values: [String] = [
             // none.
         ]
-        
+
         for string in values {
             let box = Boxed(xmlString: string)
             XCTAssertNil(box)

--- a/Tests/XMLCoderTests/Box/UIntBoxTests.swift
+++ b/Tests/XMLCoderTests/Box/UIntBoxTests.swift
@@ -10,33 +10,33 @@ import XCTest
 
 class UIntBoxTests: XCTestCase {
     typealias Boxed = UIntBox
-    
+
     func testUnbox() {
         let values: [Boxed.Unboxed] = [
             1,
             0,
-            12678967543233,
+            12_678_967_543_233,
         ]
-        
+
         for unboxed in values {
             let box = Boxed(unboxed)
             XCTAssertEqual(box.unbox(), unboxed)
         }
     }
-    
+
     func testXMLString() {
         let values: [(Boxed.Unboxed, String)] = [
             (1, "1"),
             (0, "0"),
-            (12678967543233, "12678967543233"),
+            (12_678_967_543_233, "12678967543233"),
         ]
-        
+
         for (unboxed, string) in values {
             let box = Boxed(unboxed)
             XCTAssertEqual(box.xmlString(), string)
         }
     }
-    
+
     func testValidValues() {
         let values: [String] = [
             "1",
@@ -44,20 +44,20 @@ class UIntBoxTests: XCTestCase {
             "12678967543233",
             "+100000",
         ]
-        
+
         for string in values {
             let box = Boxed(xmlString: string)
             XCTAssertNotNil(box)
         }
     }
-    
+
     func testInvalidValues() {
         let values: [String] = [
             "-1",
             "foobar",
             "",
         ]
-        
+
         for string in values {
             let box = Boxed(xmlString: string)
             XCTAssertNil(box)

--- a/Tests/XMLCoderTests/Box/URLBoxTests.swift
+++ b/Tests/XMLCoderTests/Box/URLBoxTests.swift
@@ -10,49 +10,49 @@ import XCTest
 
 class URLBoxTests: XCTestCase {
     typealias Boxed = URLBox
-    
+
     func testUnbox() {
         let values: [Boxed.Unboxed] = [
             URL(string: "file:///")!,
             URL(string: "http://example.com")!,
         ]
-        
+
         for unboxed in values {
             let box = Boxed(unboxed)
             XCTAssertEqual(box.unbox(), unboxed)
         }
     }
-    
+
     func testXMLString() {
         let values: [(Boxed.Unboxed, String)] = [
             (URL(string: "file:///")!, "file:///"),
             (URL(string: "http://example.com")!, "http://example.com"),
         ]
-        
+
         for (bool, string) in values {
             let box = Boxed(bool)
             XCTAssertEqual(box.xmlString(), string)
         }
     }
-    
+
     func testValidValues() {
         let values: [String] = [
             "file:///",
             "http://example.com",
         ]
-        
+
         for string in values {
             let box = Boxed(xmlString: string)
             XCTAssertNotNil(box)
         }
     }
-    
+
     func testInvalidValues() {
         let values: [String] = [
             "foo\nbar",
             "",
         ]
-        
+
         for string in values {
             let box = Boxed(xmlString: string)
             XCTAssertNil(box)

--- a/Tests/XMLCoderTests/Box/UnkeyedBoxTests.swift
+++ b/Tests/XMLCoderTests/Box/UnkeyedBoxTests.swift
@@ -10,14 +10,14 @@ import XCTest
 
 class UnkeyedBoxTests: XCTestCase {
     lazy var box = UnkeyedBox([StringBox("foo"), IntBox(42)])
-    
+
     func testUnbox() {
         let unboxed = box.unbox()
         XCTAssertEqual(unboxed.count, 2)
         XCTAssertEqual(unboxed[0] as? StringBox, StringBox("foo"))
         XCTAssertEqual(unboxed[1] as? IntBox, IntBox(42))
     }
-    
+
     func testXMLString() {
         XCTAssertEqual(box.xmlString(), nil)
     }

--- a/Tests/XMLCoderTests/BreakfastTest.swift
+++ b/Tests/XMLCoderTests/BreakfastTest.swift
@@ -45,7 +45,6 @@ private let xml = """
 </breakfast_menu>
 """.data(using: .utf8)!
 
-
 private struct Menu: Codable, Equatable {
     var food: [Food]
 }
@@ -75,7 +74,7 @@ final class BreakfastTest: XCTestCase {
             XCTAssert(false, "failed to decode test xml: \(error)")
         }
     }
-    
+
     static var allTests = [
         ("testXML", testXML),
     ]

--- a/Tests/XMLCoderTests/CDTest.swift
+++ b/Tests/XMLCoderTests/CDTest.swift
@@ -12,7 +12,7 @@ import XCTest
 
 private struct CDCatalog: Codable, Equatable {
     var cds: [CD]
-    
+
     enum CodingKeys: String, CodingKey {
         case cds = "CD"
     }
@@ -25,7 +25,7 @@ private struct CD: Codable, Equatable {
     var company: String
     var price: Decimal
     var year: Int
-    
+
     enum CodingKeys: String, CodingKey {
         case title = "TITLE"
         case artist = "ARTIST"
@@ -37,11 +37,11 @@ private struct CD: Codable, Equatable {
 }
 
 private let lastCD = CD(title: "Unchain my heart",
-                                 artist: "Joe Cocker",
-                                 country: "USA",
-                                 company: "EMI",
-                                 price: 8.20,
-                                 year: 1987)
+                        artist: "Joe Cocker",
+                        country: "USA",
+                        company: "EMI",
+                        price: 8.20,
+                        year: 1987)
 
 final class CDTest: XCTestCase {
     func testXML() {
@@ -50,7 +50,7 @@ final class CDTest: XCTestCase {
 
         do {
             let cdCatalog1 = try decoder.decode(CDCatalog.self,
-                                                   from: cdCatalogXML)
+                                                from: cdCatalogXML)
             XCTAssertEqual(cdCatalog1.cds.count, 26)
             XCTAssertEqual(cdCatalog1.cds[25], lastCD)
 
@@ -64,11 +64,9 @@ final class CDTest: XCTestCase {
         } catch {
             XCTAssert(false, "failed to decode test xml: \(error)")
         }
-
     }
 
     static var allTests = [
         ("testXML", testXML),
     ]
 }
-

--- a/Tests/XMLCoderTests/Minimal/BoolTests.swift
+++ b/Tests/XMLCoderTests/Minimal/BoolTests.swift
@@ -10,35 +10,35 @@ import XCTest
 
 class BoolTests: XCTestCase {
     typealias Value = Bool
-    
+
     struct Container: Codable, Equatable {
         let value: Value
     }
-    
+
     let values: [(Value, String)] = [
         (false, "false"),
         (true, "true"),
     ]
-    
+
     func testAttribute() {
         let decoder = XMLDecoder()
         let encoder = XMLEncoder()
-        
-        encoder.nodeEncodingStrategy = .custom { codableType, _ in
+
+        encoder.nodeEncodingStrategy = .custom { _, _ in
             return { _ in .attribute }
         }
-        
+
         for (value, xmlString) in values {
             do {
                 let xmlString =
-"""
-<container value="\(xmlString)" />
-"""
+                    """
+                    <container value="\(xmlString)" />
+                    """
                 let xmlData = xmlString.data(using: .utf8)!
-                
+
                 let decoded = try decoder.decode(Container.self, from: xmlData)
                 XCTAssertEqual(decoded.value, value)
-                
+
                 let encoded = try encoder.encode(decoded, withRootKey: "container")
                 XCTAssertEqual(String(data: encoded, encoding: .utf8)!, xmlString)
             } catch {
@@ -46,26 +46,26 @@ class BoolTests: XCTestCase {
             }
         }
     }
-    
+
     func testElement() {
         let decoder = XMLDecoder()
         let encoder = XMLEncoder()
-        
+
         encoder.outputFormatting = [.prettyPrinted]
-        
+
         for (value, xmlString) in values {
             do {
                 let xmlString =
-"""
-<container>
-    <value>\(xmlString)</value>
-</container>
-"""
+                    """
+                    <container>
+                        <value>\(xmlString)</value>
+                    </container>
+                    """
                 let xmlData = xmlString.data(using: .utf8)!
-                
+
                 let decoded = try decoder.decode(Container.self, from: xmlData)
                 XCTAssertEqual(decoded.value, value)
-                
+
                 let encoded = try encoder.encode(decoded, withRootKey: "container")
                 XCTAssertEqual(String(data: encoded, encoding: .utf8)!, xmlString)
             } catch {
@@ -73,7 +73,7 @@ class BoolTests: XCTestCase {
             }
         }
     }
-    
+
     static var allTests = [
         ("testAttribute", testAttribute),
         ("testElement", testElement),

--- a/Tests/XMLCoderTests/Minimal/DataTests.swift
+++ b/Tests/XMLCoderTests/Minimal/DataTests.swift
@@ -10,36 +10,36 @@ import XCTest
 
 class DataTests: XCTestCase {
     typealias Value = Data
-    
+
     struct Container: Codable, Equatable {
         let value: Value
     }
-    
+
     let values: [(Value, String)] = [
         // FIXME:
         // (Data(base64Encoded: "")!, ""),
         (Data(base64Encoded: "bG9yZW0gaXBzdW0=")!, "bG9yZW0gaXBzdW0="),
     ]
-    
+
     func testAttribute() {
         let decoder = XMLDecoder()
         let encoder = XMLEncoder()
-        
-        encoder.nodeEncodingStrategy = .custom { codableType, _ in
+
+        encoder.nodeEncodingStrategy = .custom { _, _ in
             return { _ in .attribute }
         }
-        
+
         for (value, xmlString) in values {
             do {
                 let xmlString =
-"""
-<container value="\(xmlString)" />
-"""
+                    """
+                    <container value="\(xmlString)" />
+                    """
                 let xmlData = xmlString.data(using: .utf8)!
-                
+
                 let decoded = try decoder.decode(Container.self, from: xmlData)
                 XCTAssertEqual(decoded.value, value)
-                
+
                 let encoded = try encoder.encode(decoded, withRootKey: "container")
                 XCTAssertEqual(String(data: encoded, encoding: .utf8)!, xmlString)
             } catch {
@@ -47,26 +47,26 @@ class DataTests: XCTestCase {
             }
         }
     }
-    
+
     func testElement() {
         let decoder = XMLDecoder()
         let encoder = XMLEncoder()
-        
+
         encoder.outputFormatting = [.prettyPrinted]
-        
+
         for (value, xmlString) in values {
             do {
                 let xmlString =
-"""
-<container>
-    <value>\(xmlString)</value>
-</container>
-"""
+                    """
+                    <container>
+                        <value>\(xmlString)</value>
+                    </container>
+                    """
                 let xmlData = xmlString.data(using: .utf8)!
-                
+
                 let decoded = try decoder.decode(Container.self, from: xmlData)
                 XCTAssertEqual(decoded.value, value)
-                
+
                 let encoded = try encoder.encode(decoded, withRootKey: "container")
                 XCTAssertEqual(String(data: encoded, encoding: .utf8)!, xmlString)
             } catch {
@@ -74,7 +74,7 @@ class DataTests: XCTestCase {
             }
         }
     }
-    
+
     static var allTests = [
         ("testAttribute", testAttribute),
         ("testElement", testElement),

--- a/Tests/XMLCoderTests/Minimal/DateTests.swift
+++ b/Tests/XMLCoderTests/Minimal/DateTests.swift
@@ -10,36 +10,36 @@ import XCTest
 
 class DateTests: XCTestCase {
     typealias Value = Date
-    
+
     struct Container: Codable, Equatable {
         let value: Value
     }
-    
+
     let values: [(Value, String)] = [
         (Date(timeIntervalSince1970: 0.0), "0.0"),
     ]
-    
+
     func testAttribute() {
         let decoder = XMLDecoder()
         let encoder = XMLEncoder()
-        
-        encoder.nodeEncodingStrategy = .custom { codableType, _ in
+
+        encoder.nodeEncodingStrategy = .custom { _, _ in
             return { _ in .attribute }
         }
-        
+
         encoder.dateEncodingStrategy = .secondsSince1970
-        
+
         for (value, xmlString) in values {
             do {
                 let xmlString =
-"""
-<container value="\(xmlString)" />
-"""
+                    """
+                    <container value="\(xmlString)" />
+                    """
                 let xmlData = xmlString.data(using: .utf8)!
-                
+
                 let decoded = try decoder.decode(Container.self, from: xmlData)
                 XCTAssertEqual(decoded.value, value)
-                
+
                 let encoded = try encoder.encode(decoded, withRootKey: "container")
                 XCTAssertEqual(String(data: encoded, encoding: .utf8)!, xmlString)
             } catch {
@@ -47,28 +47,28 @@ class DateTests: XCTestCase {
             }
         }
     }
-    
+
     func testElement() {
         let decoder = XMLDecoder()
         let encoder = XMLEncoder()
-        
+
         encoder.outputFormatting = [.prettyPrinted]
-        
+
         encoder.dateEncodingStrategy = .secondsSince1970
-        
+
         for (value, xmlString) in values {
             do {
                 let xmlString =
-"""
-<container>
-    <value>\(xmlString)</value>
-</container>
-"""
+                    """
+                    <container>
+                        <value>\(xmlString)</value>
+                    </container>
+                    """
                 let xmlData = xmlString.data(using: .utf8)!
-                
+
                 let decoded = try decoder.decode(Container.self, from: xmlData)
                 XCTAssertEqual(decoded.value, value)
-                
+
                 let encoded = try encoder.encode(decoded, withRootKey: "container")
                 XCTAssertEqual(String(data: encoded, encoding: .utf8)!, xmlString)
             } catch {
@@ -76,7 +76,7 @@ class DateTests: XCTestCase {
             }
         }
     }
-    
+
     static var allTests = [
         ("testAttribute", testAttribute),
         ("testElement", testElement),

--- a/Tests/XMLCoderTests/Minimal/DecimalTests.swift
+++ b/Tests/XMLCoderTests/Minimal/DecimalTests.swift
@@ -10,36 +10,36 @@ import XCTest
 
 class DecimalTests: XCTestCase {
     typealias Value = Decimal
-    
+
     struct Container: Codable, Equatable {
         let value: Value
     }
-    
+
     let values: [(Value, String)] = [
         (Decimal(-12.34), "-12.34"),
         (Decimal(0.0), "0"),
         (Decimal(12.34), "12.34"),
     ]
-    
+
     func testAttribute() {
         let decoder = XMLDecoder()
         let encoder = XMLEncoder()
-        
-        encoder.nodeEncodingStrategy = .custom { codableType, _ in
+
+        encoder.nodeEncodingStrategy = .custom { _, _ in
             return { _ in .attribute }
         }
-        
+
         for (value, xmlString) in values {
             do {
                 let xmlString =
-"""
-<container value="\(xmlString)" />
-"""
+                    """
+                    <container value="\(xmlString)" />
+                    """
                 let xmlData = xmlString.data(using: .utf8)!
-                
+
                 let decoded = try decoder.decode(Container.self, from: xmlData)
                 XCTAssertEqual(decoded.value, value)
-                
+
                 let encoded = try encoder.encode(decoded, withRootKey: "container")
                 XCTAssertEqual(String(data: encoded, encoding: .utf8)!, xmlString)
             } catch {
@@ -47,26 +47,26 @@ class DecimalTests: XCTestCase {
             }
         }
     }
-    
+
     func testElement() {
         let decoder = XMLDecoder()
         let encoder = XMLEncoder()
-        
+
         encoder.outputFormatting = [.prettyPrinted]
-        
+
         for (value, xmlString) in values {
             do {
                 let xmlString =
-"""
-<container>
-    <value>\(xmlString)</value>
-</container>
-"""
+                    """
+                    <container>
+                        <value>\(xmlString)</value>
+                    </container>
+                    """
                 let xmlData = xmlString.data(using: .utf8)!
-                
+
                 let decoded = try decoder.decode(Container.self, from: xmlData)
                 XCTAssertEqual(decoded.value, value)
-                
+
                 let encoded = try encoder.encode(decoded, withRootKey: "container")
                 XCTAssertEqual(String(data: encoded, encoding: .utf8)!, xmlString)
             } catch {
@@ -74,7 +74,7 @@ class DecimalTests: XCTestCase {
             }
         }
     }
-    
+
     static var allTests = [
         ("testAttribute", testAttribute),
         ("testElement", testElement),

--- a/Tests/XMLCoderTests/Minimal/EmptyTests.swift
+++ b/Tests/XMLCoderTests/Minimal/EmptyTests.swift
@@ -11,38 +11,38 @@ import XCTest
 class EmptyTests: XCTestCase {
     struct Container: Codable, Equatable {
         // empty
-        
-        func encode(to encoder: Encoder) throws {
+
+        func encode(to _: Encoder) throws {
             // do nothing
         }
     }
-    
+
     func testAttribute() throws {
         let decoder = XMLDecoder()
         let encoder = XMLEncoder()
-        
-        encoder.nodeEncodingStrategy = .custom { codableType, _ in
+
+        encoder.nodeEncodingStrategy = .custom { _, _ in
             return { _ in .attribute }
         }
-        
+
         XCTAssertThrowsError(try decoder.decode(Container.self, from: Data()))
-        
+
         let encoded = try encoder.encode(Container(), withRootKey: "container")
         XCTAssertEqual(String(data: encoded, encoding: .utf8)!, "<container />")
     }
-    
+
     func testElement() throws {
         let decoder = XMLDecoder()
         let encoder = XMLEncoder()
-        
+
         encoder.outputFormatting = [.prettyPrinted]
-        
+
         XCTAssertThrowsError(try decoder.decode(Container.self, from: Data()))
-        
+
         let encoded = try encoder.encode(Container(), withRootKey: "container")
         XCTAssertEqual(String(data: encoded, encoding: .utf8)!, "<container />")
     }
-    
+
     static var allTests = [
         ("testAttribute", testAttribute),
         ("testElement", testElement),

--- a/Tests/XMLCoderTests/Minimal/FloatTests.swift
+++ b/Tests/XMLCoderTests/Minimal/FloatTests.swift
@@ -10,36 +10,36 @@ import XCTest
 
 class FloatTests: XCTestCase {
     typealias Value = Float
-    
+
     struct Container: Codable, Equatable {
         let value: Value
     }
-    
+
     let values: [(Value, String)] = [
         (-42.0, "-42.0"),
         (0.0, "0.0"),
         (42.0, "42.0"),
     ]
-    
+
     func testAttribute() {
         let decoder = XMLDecoder()
         let encoder = XMLEncoder()
-        
-        encoder.nodeEncodingStrategy = .custom { codableType, _ in
+
+        encoder.nodeEncodingStrategy = .custom { _, _ in
             return { _ in .attribute }
         }
-        
+
         for (value, xmlString) in values {
             do {
                 let xmlString =
-"""
-<container value="\(xmlString)" />
-"""
+                    """
+                    <container value="\(xmlString)" />
+                    """
                 let xmlData = xmlString.data(using: .utf8)!
-                
+
                 let decoded = try decoder.decode(Container.self, from: xmlData)
                 XCTAssertEqual(decoded.value, value)
-                
+
                 let encoded = try encoder.encode(decoded, withRootKey: "container")
                 XCTAssertEqual(String(data: encoded, encoding: .utf8)!, xmlString)
             } catch {
@@ -47,26 +47,26 @@ class FloatTests: XCTestCase {
             }
         }
     }
-    
+
     func testElement() {
         let decoder = XMLDecoder()
         let encoder = XMLEncoder()
-        
+
         encoder.outputFormatting = [.prettyPrinted]
-        
+
         for (value, xmlString) in values {
             do {
                 let xmlString =
-"""
-<container>
-    <value>\(xmlString)</value>
-</container>
-"""
+                    """
+                    <container>
+                        <value>\(xmlString)</value>
+                    </container>
+                    """
                 let xmlData = xmlString.data(using: .utf8)!
-                
+
                 let decoded = try decoder.decode(Container.self, from: xmlData)
                 XCTAssertEqual(decoded.value, value)
-                
+
                 let encoded = try encoder.encode(decoded, withRootKey: "container")
                 XCTAssertEqual(String(data: encoded, encoding: .utf8)!, xmlString)
             } catch {
@@ -74,7 +74,7 @@ class FloatTests: XCTestCase {
             }
         }
     }
-    
+
     static var allTests = [
         ("testAttribute", testAttribute),
         ("testElement", testElement),

--- a/Tests/XMLCoderTests/Minimal/IntTests.swift
+++ b/Tests/XMLCoderTests/Minimal/IntTests.swift
@@ -10,36 +10,36 @@ import XCTest
 
 class IntTests: XCTestCase {
     typealias Value = Int
-    
+
     struct Container: Codable, Equatable {
         let value: Value
     }
-    
+
     let values: [(Value, String)] = [
         (-42, "-42"),
         (0, "0"),
         (42, "42"),
     ]
-    
+
     func testAttribute() {
         let decoder = XMLDecoder()
         let encoder = XMLEncoder()
-        
-        encoder.nodeEncodingStrategy = .custom { codableType, _ in
+
+        encoder.nodeEncodingStrategy = .custom { _, _ in
             return { _ in .attribute }
         }
-        
+
         for (value, xmlString) in values {
             do {
                 let xmlString =
-"""
-<container value="\(xmlString)" />
-"""
+                    """
+                    <container value="\(xmlString)" />
+                    """
                 let xmlData = xmlString.data(using: .utf8)!
-                
+
                 let decoded = try decoder.decode(Container.self, from: xmlData)
                 XCTAssertEqual(decoded.value, value)
-                
+
                 let encoded = try encoder.encode(decoded, withRootKey: "container")
                 XCTAssertEqual(String(data: encoded, encoding: .utf8)!, xmlString)
             } catch {
@@ -47,26 +47,26 @@ class IntTests: XCTestCase {
             }
         }
     }
-    
+
     func testElement() {
         let decoder = XMLDecoder()
         let encoder = XMLEncoder()
-        
+
         encoder.outputFormatting = [.prettyPrinted]
-        
+
         for (value, xmlString) in values {
             do {
                 let xmlString =
-"""
-<container>
-    <value>\(xmlString)</value>
-</container>
-"""
+                    """
+                    <container>
+                        <value>\(xmlString)</value>
+                    </container>
+                    """
                 let xmlData = xmlString.data(using: .utf8)!
-                
+
                 let decoded = try decoder.decode(Container.self, from: xmlData)
                 XCTAssertEqual(decoded.value, value)
-                
+
                 let encoded = try encoder.encode(decoded, withRootKey: "container")
                 XCTAssertEqual(String(data: encoded, encoding: .utf8)!, xmlString)
             } catch {
@@ -74,7 +74,7 @@ class IntTests: XCTestCase {
             }
         }
     }
-    
+
     static var allTests = [
         ("testAttribute", testAttribute),
         ("testElement", testElement),

--- a/Tests/XMLCoderTests/Minimal/KeyedTests.swift
+++ b/Tests/XMLCoderTests/Minimal/KeyedTests.swift
@@ -15,82 +15,82 @@ class KeyedTests: XCTestCase {
 
     func testEmpty() {
         let decoder = XMLDecoder()
-        
+
         do {
             let xmlString =
-"""
-<?xml version="1.0" encoding="UTF-8"?>
-<container>
-</container>
-"""
-                let xmlData = xmlString.data(using: .utf8)!
-            
+                """
+                <?xml version="1.0" encoding="UTF-8"?>
+                <container>
+                </container>
+                """
+            let xmlData = xmlString.data(using: .utf8)!
+
             let decoded = try decoder.decode(Container.self, from: xmlData)
             XCTAssertEqual(decoded.value, [:])
         } catch {
             XCTAssert(false, "failed to decode test xml: \(error)")
         }
     }
-    
+
     func testSingleElement() {
         let decoder = XMLDecoder()
-        
+
         do {
             let xmlString =
-"""
-<?xml version="1.0" encoding="UTF-8"?>
-<container>
-    <value>
-        <foo>12</foo>
-    </value>
-</container>
-"""
-                let xmlData = xmlString.data(using: .utf8)!
-            
+                """
+                <?xml version="1.0" encoding="UTF-8"?>
+                <container>
+                    <value>
+                        <foo>12</foo>
+                    </value>
+                </container>
+                """
+            let xmlData = xmlString.data(using: .utf8)!
+
             let decoded = try decoder.decode(Container.self, from: xmlData)
             XCTAssertEqual(decoded.value, ["foo": 12])
         } catch {
             XCTAssert(false, "failed to decode test xml: \(error)")
         }
     }
-    
+
     func testMultiElement() {
         let decoder = XMLDecoder()
-        
+
         do {
             let xmlString =
-"""
-<?xml version="1.0" encoding="UTF-8"?>
-<container>
-    <value>
-        <foo>12</foo>
-        <bar>34</bar>
-    </value>
-</container>
-"""
-                let xmlData = xmlString.data(using: .utf8)!
-            
+                """
+                <?xml version="1.0" encoding="UTF-8"?>
+                <container>
+                    <value>
+                        <foo>12</foo>
+                        <bar>34</bar>
+                    </value>
+                </container>
+                """
+            let xmlData = xmlString.data(using: .utf8)!
+
             let decoded = try decoder.decode(Container.self, from: xmlData)
             XCTAssertEqual(decoded.value, ["foo": 12, "bar": 34])
         } catch {
             XCTAssert(false, "failed to decode test xml: \(error)")
         }
     }
-    
+
     func testAttribute() {
         let encoder = XMLEncoder()
-        
-        encoder.nodeEncodingStrategy = .custom { codableType, _ in
+
+        encoder.nodeEncodingStrategy = .custom { _, _ in
             return { _ in .attribute }
         }
-        
+
         let container = Container(value: ["foo": 12, "bar": 34])
-        
+
         XCTAssertThrowsError(
             try encoder.encode(container, withRootKey: "container")
         )
     }
-    
+
     static var allTests = [
         ("testEmpty", testEmpty),
         ("testSingleElement", testSingleElement),

--- a/Tests/XMLCoderTests/Minimal/NullTests.swift
+++ b/Tests/XMLCoderTests/Minimal/NullTests.swift
@@ -16,51 +16,51 @@ class NullTests: XCTestCase {
     func testAttribute() {
         let decoder = XMLDecoder()
         let encoder = XMLEncoder()
-        
-        encoder.nodeEncodingStrategy = .custom { codableType, _ in
+
+        encoder.nodeEncodingStrategy = .custom { _, _ in
             return { _ in .attribute }
         }
-        
+
         do {
             let xmlString =
-"""
-<container />
-"""
+                """
+                <container />
+                """
             let xmlData = xmlString.data(using: .utf8)!
-            
+
             let decoded = try decoder.decode(Container.self, from: xmlData)
             XCTAssertNil(decoded.value)
-            
+
             let encoded = try encoder.encode(decoded, withRootKey: "container")
             XCTAssertEqual(String(data: encoded, encoding: .utf8)!, xmlString)
         } catch {
             XCTAssert(false, "failed to decode test xml: \(error)")
         }
     }
-    
+
     func testElement() {
         let decoder = XMLDecoder()
         let encoder = XMLEncoder()
-        
+
         encoder.outputFormatting = [.prettyPrinted]
-        
+
         do {
             let xmlString =
-"""
-<container />
-"""
+                """
+                <container />
+                """
             let xmlData = xmlString.data(using: .utf8)!
-            
+
             let decoded = try decoder.decode(Container.self, from: xmlData)
             XCTAssertNil(decoded.value)
-            
+
             let encoded = try encoder.encode(decoded, withRootKey: "container")
             XCTAssertEqual(String(data: encoded, encoding: .utf8)!, xmlString)
         } catch {
             XCTAssert(false, "failed to decode test xml: \(error)")
         }
     }
-    
+
     static var allTests = [
         ("testAttribute", testAttribute),
         ("testElement", testElement),

--- a/Tests/XMLCoderTests/Minimal/StringTests.swift
+++ b/Tests/XMLCoderTests/Minimal/StringTests.swift
@@ -10,11 +10,11 @@ import XCTest
 
 class StringTests: XCTestCase {
     typealias Value = String
-    
+
     struct Container: Codable, Equatable {
         let value: Value
     }
-    
+
     let values: [(Value, String)] = [
         // FIXME!
         // ("", ""),
@@ -24,26 +24,26 @@ class StringTests: XCTestCase {
         ("42.0", "42.0"),
         ("foobar", "foobar"),
     ]
-    
+
     func testAttribute() {
         let decoder = XMLDecoder()
         let encoder = XMLEncoder()
-        
-        encoder.nodeEncodingStrategy = .custom { codableType, _ in
+
+        encoder.nodeEncodingStrategy = .custom { _, _ in
             return { _ in .attribute }
         }
-        
+
         for (value, xmlString) in values {
             do {
                 let xmlString =
-"""
-<container value="\(xmlString)" />
-"""
+                    """
+                    <container value="\(xmlString)" />
+                    """
                 let xmlData = xmlString.data(using: .utf8)!
-                
+
                 let decoded = try decoder.decode(Container.self, from: xmlData)
                 XCTAssertEqual(decoded.value, value)
-                
+
                 let encoded = try encoder.encode(decoded, withRootKey: "container")
                 XCTAssertEqual(String(data: encoded, encoding: .utf8)!, xmlString)
             } catch {
@@ -51,26 +51,26 @@ class StringTests: XCTestCase {
             }
         }
     }
-    
+
     func testElement() {
         let decoder = XMLDecoder()
         let encoder = XMLEncoder()
-        
+
         encoder.outputFormatting = [.prettyPrinted]
-        
+
         for (value, xmlString) in values {
             do {
                 let xmlString =
-"""
-<container>
-    <value>\(xmlString)</value>
-</container>
-"""
+                    """
+                    <container>
+                        <value>\(xmlString)</value>
+                    </container>
+                    """
                 let xmlData = xmlString.data(using: .utf8)!
-                
+
                 let decoded = try decoder.decode(Container.self, from: xmlData)
                 XCTAssertEqual(decoded.value, value)
-                
+
                 let encoded = try encoder.encode(decoded, withRootKey: "container")
                 XCTAssertEqual(String(data: encoded, encoding: .utf8)!, xmlString)
             } catch {
@@ -78,7 +78,7 @@ class StringTests: XCTestCase {
             }
         }
     }
-    
+
     static var allTests = [
         ("testAttribute", testAttribute),
         ("testElement", testElement),

--- a/Tests/XMLCoderTests/Minimal/UIntTests.swift
+++ b/Tests/XMLCoderTests/Minimal/UIntTests.swift
@@ -10,35 +10,35 @@ import XCTest
 
 class UIntTests: XCTestCase {
     typealias Value = UInt
-    
+
     struct Container: Codable, Equatable {
         let value: Value
     }
-    
+
     let values: [(Value, String)] = [
         (0, "0"),
         (42, "42"),
     ]
-    
+
     func testAttribute() {
         let decoder = XMLDecoder()
         let encoder = XMLEncoder()
-        
-        encoder.nodeEncodingStrategy = .custom { codableType, _ in
+
+        encoder.nodeEncodingStrategy = .custom { _, _ in
             return { _ in .attribute }
         }
-        
+
         for (value, xmlString) in values {
             do {
                 let xmlString =
-"""
-<container value="\(xmlString)" />
-"""
+                    """
+                    <container value="\(xmlString)" />
+                    """
                 let xmlData = xmlString.data(using: .utf8)!
-                
+
                 let decoded = try decoder.decode(Container.self, from: xmlData)
                 XCTAssertEqual(decoded.value, value)
-                
+
                 let encoded = try encoder.encode(decoded, withRootKey: "container")
                 XCTAssertEqual(String(data: encoded, encoding: .utf8)!, xmlString)
             } catch {
@@ -46,26 +46,26 @@ class UIntTests: XCTestCase {
             }
         }
     }
-    
+
     func testElement() {
         let decoder = XMLDecoder()
         let encoder = XMLEncoder()
-        
+
         encoder.outputFormatting = [.prettyPrinted]
-        
+
         for (value, xmlString) in values {
             do {
                 let xmlString =
-"""
-<container>
-    <value>\(xmlString)</value>
-</container>
-"""
+                    """
+                    <container>
+                        <value>\(xmlString)</value>
+                    </container>
+                    """
                 let xmlData = xmlString.data(using: .utf8)!
-                
+
                 let decoded = try decoder.decode(Container.self, from: xmlData)
                 XCTAssertEqual(decoded.value, value)
-                
+
                 let encoded = try encoder.encode(decoded, withRootKey: "container")
                 XCTAssertEqual(String(data: encoded, encoding: .utf8)!, xmlString)
             } catch {
@@ -73,7 +73,7 @@ class UIntTests: XCTestCase {
             }
         }
     }
-    
+
     static var allTests = [
         ("testAttribute", testAttribute),
         ("testElement", testElement),

--- a/Tests/XMLCoderTests/Minimal/URLTests.swift
+++ b/Tests/XMLCoderTests/Minimal/URLTests.swift
@@ -10,35 +10,35 @@ import XCTest
 
 class URLTests: XCTestCase {
     typealias Value = URL
-    
+
     struct Container: Codable, Equatable {
         let value: Value
     }
-    
+
     let values: [(Value, String)] = [
         (URL(string: "file:///")!, "file:///"),
         (URL(string: "http://example.com")!, "http://example.com"),
     ]
-    
+
     func testAttribute() {
         let decoder = XMLDecoder()
         let encoder = XMLEncoder()
-        
-        encoder.nodeEncodingStrategy = .custom { codableType, _ in
+
+        encoder.nodeEncodingStrategy = .custom { _, _ in
             return { _ in .attribute }
         }
-        
+
         for (value, xmlString) in values {
             do {
                 let xmlString =
-"""
-<container value="\(xmlString)" />
-"""
+                    """
+                    <container value="\(xmlString)" />
+                    """
                 let xmlData = xmlString.data(using: .utf8)!
-                
+
                 let decoded = try decoder.decode(Container.self, from: xmlData)
                 XCTAssertEqual(decoded.value, value)
-                
+
                 let encoded = try encoder.encode(decoded, withRootKey: "container")
                 XCTAssertEqual(String(data: encoded, encoding: .utf8)!, xmlString)
             } catch {
@@ -46,26 +46,26 @@ class URLTests: XCTestCase {
             }
         }
     }
-    
+
     func testElement() {
         let decoder = XMLDecoder()
         let encoder = XMLEncoder()
-        
+
         encoder.outputFormatting = [.prettyPrinted]
-        
+
         for (value, xmlString) in values {
             do {
                 let xmlString =
-"""
-<container>
-    <value>\(xmlString)</value>
-</container>
-"""
+                    """
+                    <container>
+                        <value>\(xmlString)</value>
+                    </container>
+                    """
                 let xmlData = xmlString.data(using: .utf8)!
-                
+
                 let decoded = try decoder.decode(Container.self, from: xmlData)
                 XCTAssertEqual(decoded.value, value)
-                
+
                 let encoded = try encoder.encode(decoded, withRootKey: "container")
                 XCTAssertEqual(String(data: encoded, encoding: .utf8)!, xmlString)
             } catch {
@@ -73,7 +73,7 @@ class URLTests: XCTestCase {
             }
         }
     }
-    
+
     static var allTests = [
         ("testAttribute", testAttribute),
         ("testElement", testElement),

--- a/Tests/XMLCoderTests/Minimal/UnkeyedTests.swift
+++ b/Tests/XMLCoderTests/Minimal/UnkeyedTests.swift
@@ -15,78 +15,78 @@ class UnkeyedTests: XCTestCase {
 
     func testEmpty() {
         let decoder = XMLDecoder()
-        
+
         do {
             let xmlString =
-"""
-<?xml version="1.0" encoding="UTF-8"?>
-<container>
-</container>
-"""
-                let xmlData = xmlString.data(using: .utf8)!
-            
+                """
+                <?xml version="1.0" encoding="UTF-8"?>
+                <container>
+                </container>
+                """
+            let xmlData = xmlString.data(using: .utf8)!
+
             let decoded = try decoder.decode(Container.self, from: xmlData)
             XCTAssertEqual(decoded.value, [])
         } catch {
             XCTAssert(false, "failed to decode test xml: \(error)")
         }
     }
-    
+
     func testSingleElement() {
         let decoder = XMLDecoder()
-        
+
         do {
             let xmlString =
-"""
-<?xml version="1.0" encoding="UTF-8"?>
-<container>
-    <value>foo</value>
-</container>
-"""
-                let xmlData = xmlString.data(using: .utf8)!
-            
+                """
+                <?xml version="1.0" encoding="UTF-8"?>
+                <container>
+                    <value>foo</value>
+                </container>
+                """
+            let xmlData = xmlString.data(using: .utf8)!
+
             let decoded = try decoder.decode(Container.self, from: xmlData)
             XCTAssertEqual(decoded.value, ["foo"])
         } catch {
             XCTAssert(false, "failed to decode test xml: \(error)")
         }
     }
-    
+
     func testMultiElement() {
         let decoder = XMLDecoder()
-        
+
         do {
             let xmlString =
-"""
-<?xml version="1.0" encoding="UTF-8"?>
-<container>
-    <value>foo</value>
-    <value>bar</value>
-</container>
-"""
-                let xmlData = xmlString.data(using: .utf8)!
-            
+                """
+                <?xml version="1.0" encoding="UTF-8"?>
+                <container>
+                    <value>foo</value>
+                    <value>bar</value>
+                </container>
+                """
+            let xmlData = xmlString.data(using: .utf8)!
+
             let decoded = try decoder.decode(Container.self, from: xmlData)
             XCTAssertEqual(decoded.value, ["foo", "bar"])
         } catch {
             XCTAssert(false, "failed to decode test xml: \(error)")
         }
     }
-    
+
     func testAttribute() {
         let encoder = XMLEncoder()
-        
-        encoder.nodeEncodingStrategy = .custom { codableType, _ in
+
+        encoder.nodeEncodingStrategy = .custom { _, _ in
             return { _ in .attribute }
         }
-        
+
         let container = Container(value: ["foo", "bar"])
-        
+
         XCTAssertThrowsError(
             try encoder.encode(container, withRootKey: "container")
         )
     }
-    
+
     static var allTests = [
         ("testEmpty", testEmpty),
         ("testSingleElement", testSingleElement),

--- a/Tests/XMLCoderTests/NodeEncodingStrategyTests.swift
+++ b/Tests/XMLCoderTests/NodeEncodingStrategyTests.swift
@@ -76,7 +76,7 @@ final class NodeEncodingStrategyTests: XCTestCase {
         }
 
         let encoder = XMLEncoder()
-        
+
         encoder.outputFormatting = [.prettyPrinted, .sortedKeys]
 
         do {

--- a/Tests/XMLCoderTests/NoteTest.swift
+++ b/Tests/XMLCoderTests/NoteTest.swift
@@ -47,7 +47,7 @@ final class NoteTest: XCTestCase {
             XCTAssertEqual(note1.from, "Jani")
             XCTAssertEqual(note1.heading, "Reminder")
             XCTAssertEqual(note1.body, "Don't forget me this weekend!")
-            
+
             let data = try encoder.encode(note1, withRootKey: "note",
                                           header: XMLHeader(version: 1.0,
                                                             encoding: "UTF-8"))
@@ -57,18 +57,18 @@ final class NoteTest: XCTestCase {
             XCTAssert(false, "failed to decode test xml: \(error)")
         }
     }
-    
+
     func testInvalidXML() {
         let decoder = XMLDecoder()
-        
+
         do {
-            let _ = try decoder.decode(Note.self, from: invalidXml)
+            _ = try decoder.decode(Note.self, from: invalidXml)
             XCTFail("Expected failure due to malformed XML.")
         } catch {
             // success!
         }
     }
-    
+
     static var allTests = [
         ("testValidXML", testValidXML),
         ("testInvalidXML", testInvalidXML),

--- a/Tests/XMLCoderTests/PlantTest.swift
+++ b/Tests/XMLCoderTests/PlantTest.swift
@@ -12,14 +12,13 @@ import XCTest
 
 private struct PlantCatalog: Codable, Equatable {
     var plants: [Plant]
-    
+
     enum CodingKeys: String, CodingKey {
         case plants = "PLANT"
     }
 }
 
-private struct CurrencyCodingError: Error {
-}
+private struct CurrencyCodingError: Error {}
 
 private struct Currency: Codable, Equatable {
     let value: Decimal
@@ -39,7 +38,7 @@ private struct Currency: Codable, Equatable {
         let container = try decoder.singleValueContainer()
         let string = try container.decode(String.self)
         guard let value = Currency.formatter
-        .number(from: string)?.decimalValue else {
+            .number(from: string)?.decimalValue else {
             throw CurrencyCodingError()
         }
 
@@ -60,7 +59,7 @@ private struct Plant: Codable, Equatable {
     var light: String
     var price: Currency
     var amountAvailable: Int
-    
+
     enum CodingKeys: String, CodingKey {
         case common = "COMMON"
         case botanical = "BOTANICAL"
@@ -69,7 +68,7 @@ private struct Plant: Codable, Equatable {
         case price = "PRICE"
         case amountAvailable = "AVAILABILITY"
     }
-    
+
     init(common: String,
          botanical: String,
          zone: String,
@@ -84,7 +83,6 @@ private struct Plant: Codable, Equatable {
         self.amountAvailable = amountAvailable
     }
 
-    
     init(from decoder: Decoder) throws {
         let values = try decoder.container(keyedBy: CodingKeys.self)
         let common = try values.decode(String.self, forKey: .common)
@@ -93,7 +91,7 @@ private struct Plant: Codable, Equatable {
         let light = try values.decode(String.self, forKey: .light)
         let price = try values.decode(Currency.self, forKey: .price)
         let availability = try values.decode(Int.self, forKey: .amountAvailable)
-        
+
         self.init(common: common,
                   botanical: botanical,
                   zone: zone,
@@ -114,7 +112,7 @@ final class PlantTest: XCTestCase {
     func testXML() {
         let decoder = XMLDecoder()
         let encoder = XMLEncoder()
-        
+
         do {
             let plantCatalog1 = try decoder.decode(PlantCatalog.self,
                                                    from: plantCatalogXML)
@@ -130,7 +128,6 @@ final class PlantTest: XCTestCase {
         } catch {
             XCTAssert(false, "failed to decode test xml: \(error)")
         }
-
     }
 
     static var allTests = [

--- a/Tests/XMLCoderTests/RJITest.swift
+++ b/Tests/XMLCoderTests/RJITest.swift
@@ -17,10 +17,10 @@ class RJITest: XCTestCase {
         let rdf: URL
         let content: URL
         let channel: Channel
-        
+
         enum CodingKeys: String, CodingKey {
-            case channel = "channel"
-            
+            case channel
+
             case dc = "xmlns:dc"
             case sy = "xmlns:sy"
             case admin = "xmlns:admin"
@@ -28,7 +28,7 @@ class RJITest: XCTestCase {
             case content = "xmlns:content"
         }
     }
-    
+
     struct Channel: Codable, Equatable {
         let title: String
         let link: URL
@@ -40,10 +40,10 @@ class RJITest: XCTestCase {
         let generatorAgentResource: URL
         let image: Image
         let items: [Item]
-        
+
         enum CodingKeys: String, CodingKey {
             case title, link, description, image
-            
+
             case language = "dc:language"
             case creator = "dc:creator"
             case rights = "dc:rights"
@@ -51,11 +51,11 @@ class RJITest: XCTestCase {
             case generatorAgentResource = "admin:generatorAgent"
             case items = "item"
         }
-        
+
         enum GeneratorAgentKeys: String, CodingKey {
             case resource = "rdf:resource"
         }
-        
+
         init(title: String, link: URL,
              description: String,
              language: String,
@@ -76,25 +76,25 @@ class RJITest: XCTestCase {
             self.image = image
             self.items = items
         }
-        
+
         init(from decoder: Decoder) throws {
             let values = try decoder.container(keyedBy: CodingKeys.self)
-            self.title = try values.decode(String.self, forKey: .title)
-            self.link = try values.decode(URL.self, forKey: .link)
-            self.description = try values.decodeIfPresent(String.self, forKey: .description)
-            self.language = try values.decode(String.self, forKey: .language)
-            self.creator = try values.decode(String.self, forKey: .creator)
-            self.rights = try values.decode(String.self, forKey: .rights)
-            self.date = try values.decode(Date.self, forKey: .date)
-            
+            title = try values.decode(String.self, forKey: .title)
+            link = try values.decode(URL.self, forKey: .link)
+            description = try values.decodeIfPresent(String.self, forKey: .description)
+            language = try values.decode(String.self, forKey: .language)
+            creator = try values.decode(String.self, forKey: .creator)
+            rights = try values.decode(String.self, forKey: .rights)
+            date = try values.decode(Date.self, forKey: .date)
+
             let generatorAgentValues = try values.nestedContainer(keyedBy: GeneratorAgentKeys.self, forKey: .generatorAgentResource)
-            self.generatorAgentResource = try generatorAgentValues.decode(URL.self, forKey: .resource)
-            
-            self.image = try values.decode(Image.self, forKey: .image)
-            self.items = try values.decode([Item].self, forKey: .items)
+            generatorAgentResource = try generatorAgentValues.decode(URL.self, forKey: .resource)
+
+            image = try values.decode(Image.self, forKey: .image)
+            items = try values.decode([Item].self, forKey: .items)
         }
     }
-    
+
     struct Image: Codable, Equatable {
         let url: URL
         let height: Int
@@ -102,7 +102,7 @@ class RJITest: XCTestCase {
         let link: URL
         let title: String
     }
-    
+
     struct Item: Codable, Equatable {
         let title: String
         let link: URL
@@ -112,35 +112,35 @@ class RJITest: XCTestCase {
         let subject: String?
         let date: Date
         let author: String?
-        
+
         enum CodingKeys: String, CodingKey {
             case title, link, guid, enclosure, description
-            
+
             case subject = "dc:subject"
             case date = "dc:date"
             case author
         }
-        
+
         init(from decoder: Decoder) throws {
             let values = try decoder.container(keyedBy: CodingKeys.self)
-            
-            self.title = try values.decode(String.self, forKey: .title)
-            self.link = try values.decode(URL.self, forKey: .link)
-            self.guid = try values.decode(URL.self, forKey: .guid)
-            self.enclosure = try values.decodeIfPresent(Enclosure.self, forKey: .enclosure)
-            self.description = try values.decode(String.self, forKey: .description)
-            self.subject = try values.decodeIfPresent(String.self, forKey: .subject)
-            self.date = try values.decode(Date.self, forKey: .date)
-            self.author = try values.decodeIfPresent(String.self, forKey: .author)
+
+            title = try values.decode(String.self, forKey: .title)
+            link = try values.decode(URL.self, forKey: .link)
+            guid = try values.decode(URL.self, forKey: .guid)
+            enclosure = try values.decodeIfPresent(Enclosure.self, forKey: .enclosure)
+            description = try values.decode(String.self, forKey: .description)
+            subject = try values.decodeIfPresent(String.self, forKey: .subject)
+            date = try values.decode(Date.self, forKey: .date)
+            author = try values.decodeIfPresent(String.self, forKey: .author)
         }
     }
-    
+
     struct Enclosure: Codable, Equatable {
         let url: URL
         let length: String
         let type: String
     }
-    
+
     func testRSS() {
         let decoder = XMLDecoder()
 //        let encoder = XMLEncoder()
@@ -148,12 +148,12 @@ class RJITest: XCTestCase {
         let dateFormatter = DateFormatter()
         dateFormatter.dateFormat = "yyyy-MM-dd'T'HH:mm:ssZZZZZ"
         decoder.dateDecodingStrategy = .formatted(dateFormatter)
-        
+
         do {
 //            let rss1
             _ = try decoder.decode(RSS.self, from: rjiSampleXML)
-// this is a very peculiar case of `XMLCoder` not being able to decode an XML
-// that it itself encoded
+            // this is a very peculiar case of `XMLCoder` not being able to decode an XML
+            // that it itself encoded
 //            data = try encoder.encode(rss1, withRootKey: "note",
 //                                      header: XMLHeader(version: 1.0,
 //                                                        encoding: "UTF-8"))
@@ -163,10 +163,10 @@ class RJITest: XCTestCase {
             XCTAssert(false, "failed to decode test xml: \(error)")
         }
     }
-    
+
     func testBenchmarkRSS() throws {
         let decoder = XMLDecoder()
-        
+
         let dateFormatter = DateFormatter()
         dateFormatter.dateFormat = "yyyy-MM-dd'T'HH:mm:ssZZZZZ"
         decoder.dateDecodingStrategy = .formatted(dateFormatter)
@@ -179,7 +179,7 @@ class RJITest: XCTestCase {
             }
         }
     }
-    
+
     static var allTests = [
         ("testRSS", testRSS),
         ("testBenchmarkRSS", testBenchmarkRSS),


### PR DESCRIPTION
We currently have a plenty of formatting issues such as inconsistent indentation, trailing whitespaces etc in the codebase. In addition, formatting-related coding style approaches are not enforced. Here latest changes from SwiftFormat are applied and in addition it is set up to execute checks on CI.