### PR TITLE
Let compiler synthesize Equatable conformance for _XMLElement

### DIFF
--- a/Sources/XMLCoder/Auxiliaries/XMLElement.swift
+++ b/Sources/XMLCoder/Auxiliaries/XMLElement.swift
@@ -230,4 +230,4 @@ struct _XMLElement {
     }
 }
 
-extension _XMLElement: Equatable { }
+extension _XMLElement: Equatable {}

--- a/Sources/XMLCoder/Auxiliaries/XMLElement.swift
+++ b/Sources/XMLCoder/Auxiliaries/XMLElement.swift
@@ -230,16 +230,4 @@ struct _XMLElement {
     }
 }
 
-extension _XMLElement: Equatable {
-    static func == (lhs: _XMLElement, rhs: _XMLElement) -> Bool {
-        guard
-            lhs.key == rhs.key,
-            lhs.value == rhs.value,
-            lhs.attributes == rhs.attributes,
-            lhs.elements == rhs.elements
-        else {
-            return false
-        }
-        return true
-    }
-}
+extension _XMLElement: Equatable { }


### PR DESCRIPTION
As `_XMLElement` was made a `struct` in 1f0cb9d91178678b64e251a5b761dbee7f519445, we can let the compiler synthesize `Equatable` conformance for free.

This PR removes the custom `_XMLElement: Equatable` conformance implementation.