### PR TITLE
[RFC] Add OrderedDictionary

### DIFF
--- a/Sources/XMLCoder/Auxiliaries/OrderedDictionary.swift
+++ b/Sources/XMLCoder/Auxiliaries/OrderedDictionary.swift
@@ -102,7 +102,7 @@ struct OrderedDictionary <Key: Hashable, Value> {
         by areInIncreasingOrder: ((key: Key, value: Value), (key: Key, value: Value)) throws -> Bool
     ) rethrows -> OrderedDictionary
     {
-        return OrderedDictionary(uniqueKeysWithValues: try self.sorted(by: areInIncreasingOrder))
+        return OrderedDictionary(uniqueKeysWithValues: try sorted(by: areInIncreasingOrder))
     }
 }
 

--- a/Sources/XMLCoder/Auxiliaries/OrderedDictionary.swift
+++ b/Sources/XMLCoder/Auxiliaries/OrderedDictionary.swift
@@ -14,7 +14,7 @@ struct OrderedDictionary <Key: Hashable, Value> {
     var keys: [Key] = []
 
     /// - Returns: The values in order.
-    public var values: [Value] {
+    var values: [Value] {
         return keys.map { self[$0]! }
     }
 
@@ -63,7 +63,7 @@ struct OrderedDictionary <Key: Hashable, Value> {
     // MARK: - Subscripts
 
     /// - Returns: Value for the given `key`, if available. Otherwise, `nil`.
-    public subscript(key: Key) -> Value? {
+    subscript(key: Key) -> Value? {
         get {
             return unordered[key]
         }
@@ -111,23 +111,23 @@ extension OrderedDictionary: Collection {
     // MARK: - Collection
 
     /// - Index after given index `i`.
-    public func index(after i: Int) -> Int {
+    func index(after i: Int) -> Int {
         precondition(i < endIndex, "Cannot increment beyond endIndex")
         return i + 1
     }
 
     /// Start index.
-    public var startIndex: Int {
+    var startIndex: Int {
         return keys.startIndex
     }
 
     /// End index.
-    public var endIndex: Int {
+    var endIndex: Int {
         return keys.endIndex
     }
 
     /// - Returns: Element at the given `index`.
-    public subscript (index: Int) -> (key: Key, value: Value) {
+    subscript (index: Int) -> (key: Key, value: Value) {
         let key = keys[index]
         let value = unordered[key]!
         return (key,value)
@@ -142,7 +142,7 @@ extension OrderedDictionary: ExpressibleByDictionaryLiteral {
     // MARK: - ExpressibleByDictionaryLiteral
 
     /// Create an `OrderedDictionary` with a `DictionaryLiteral`.
-    public init(dictionaryLiteral elements: (Key,Value)...) {
+    init(dictionaryLiteral elements: (Key,Value)...) {
         self.init(minimumCapacity: elements.count)
         elements.forEach { (k,v) in append(v, key: k) }
     }
@@ -153,7 +153,7 @@ extension OrderedDictionary: CustomStringConvertible {
     // MARK: - CustomStringConvertible
 
     /// - Returns: A string that represents the contents of the `OrderedDictionary`.
-    public var description: String {
+    var description: String {
         if self.count == 0 { return "[:]" }
         var result = "["
         var first = true

--- a/Sources/XMLCoder/Auxiliaries/OrderedDictionary.swift
+++ b/Sources/XMLCoder/Auxiliaries/OrderedDictionary.swift
@@ -11,7 +11,7 @@ struct OrderedDictionary <Key: Hashable, Value> {
     // MARK: - Instance Properties
 
     /// Keys in order.
-    var keys: [Key] = []
+    private(set) var keys: [Key] = []
 
     /// - Returns: The values in order.
     var values: [Value] {

--- a/Sources/XMLCoder/Auxiliaries/OrderedDictionary.swift
+++ b/Sources/XMLCoder/Auxiliaries/OrderedDictionary.swift
@@ -100,9 +100,9 @@ struct OrderedDictionary <Key: Hashable, Value> {
     /// - Returns: An array of key-value pairs sorted by the given comparison closure.
     func sorted(
         by areInIncreasingOrder: ((key: Key, value: Value), (key: Key, value: Value)) throws -> Bool
-    ) rethrows -> [(key: Key, value: Value)]
+    ) rethrows -> OrderedDictionary
     {
-        return try Array(self).sorted(by: areInIncreasingOrder)
+        return OrderedDictionary(uniqueKeysWithValues: try self.sorted(by: areInIncreasingOrder))
     }
 }
 

--- a/Sources/XMLCoder/Auxiliaries/OrderedDictionary.swift
+++ b/Sources/XMLCoder/Auxiliaries/OrderedDictionary.swift
@@ -1,0 +1,184 @@
+//
+//  OrderedDictionary.swift
+//  XMLCoder
+//
+//  Created by James Bean on 12/22/18.
+//
+
+/// Ordered collection of key-value pairs.
+struct OrderedDictionary <Key: Hashable, Value> {
+
+    // MARK: - Instance Properties
+
+    /// Keys in order.
+    var keys: [Key] = []
+
+    /// - Returns: The values in order.
+    public var values: [Value] {
+        return keys.map { self[$0]! }
+    }
+
+    /// Unordered dictionary of key-value pairs.
+    private var unordered: [Key: Value] = [:]
+
+    // MARK: - Initializers
+
+    /// Creates an empty `OrderedDictionary`.
+    init(keys: [Key] = [], unordered: [Key: Value] = [:]) {
+        self.keys = keys
+        self.unordered = unordered
+    }
+
+    /// Creates an `OrderedDictionary` from an unordered `Dictionary`.
+    init(_ unordered: [Key: Value]) {
+        self.init(keys: Array(unordered.keys), unordered: unordered)
+    }
+
+    /// Creates an `OrderedDictionary` with given array of `uniqueKeysWithValues`.
+    init(uniqueKeysWithValues: [(Key,Value)]) {
+        let keys = uniqueKeysWithValues.map { $0.0 }
+        let unordered = Dictionary(uniqueKeysWithValues: uniqueKeysWithValues)
+        self.init(keys: keys, unordered: unordered)
+    }
+
+    /// Creates an `OrderedDictionary` with the given `keysAndValues` along with the `uniquingKeys
+    init <S> (
+        _ keysAndValues: S,
+        uniquingKeysWith combine: (Value, Value) throws -> Value
+    ) rethrows where S : Sequence, S.Element == (Key,Value)
+    {
+        let unordered = try Dictionary(keysAndValues, uniquingKeysWith: combine)
+        let keys = keysAndValues.map { $0.0 }.removingDuplicates()
+        self.init(keys: keys, unordered: unordered)
+    }
+
+    /// Creates an empty `OrderedDictionary` type with preallocated space for at least the specified
+    /// number of elements.
+    init(minimumCapacity: Int) {
+        self.keys = []
+        self.keys.reserveCapacity(minimumCapacity)
+        self.unordered = .init(minimumCapacity: minimumCapacity)
+    }
+
+    // MARK: - Subscripts
+
+    /// - Returns: Value for the given `key`, if available. Otherwise, `nil`.
+    public subscript(key: Key) -> Value? {
+        get {
+            return unordered[key]
+        }
+        set {
+            guard let newValue = newValue else {
+                unordered.removeValue(forKey: key)
+                keys.removeAll { $0 == key }
+                return
+            }
+            let oldValue = unordered.updateValue(newValue, forKey: key)
+            if oldValue == nil { keys.append(key) }
+        }
+    }
+
+    // MARK: - Instance Methods
+
+    /// Appends `value` for given `key`.
+    mutating func append(_ value: Value, key: Key) {
+        keys.append(key)
+        unordered[key] = value
+    }
+
+    /// Inserts `value` for given `key` at `index`.
+    mutating func insert(_ value: Value, key: Key, index: Int) {
+        keys.insert(key, at: index)
+        unordered[key] = value
+    }
+
+    /// - Returns: An `OrderedDictionary` with values mapped by the given `transform`.
+    func mapValues <U> (_ transform: (Value) throws -> U) rethrows -> OrderedDictionary<Key,U> {
+        return OrderedDictionary<Key,U>(keys: keys, unordered: try unordered.mapValues(transform))
+    }
+
+    /// - Returns: An array of key-value pairs sorted by the given comparison closure.
+    func sorted(
+        by areInIncreasingOrder: ((key: Key, value: Value), (key: Key, value: Value)) throws -> Bool
+    ) rethrows -> [(key: Key, value: Value)]
+    {
+        return try Array(self).sorted(by: areInIncreasingOrder)
+    }
+}
+
+extension OrderedDictionary: Collection {
+
+    // MARK: - Collection
+
+    /// - Index after given index `i`.
+    public func index(after i: Int) -> Int {
+        precondition(i < endIndex, "Cannot increment beyond endIndex")
+        return i + 1
+    }
+
+    /// Start index.
+    public var startIndex: Int {
+        return keys.startIndex
+    }
+
+    /// End index.
+    public var endIndex: Int {
+        return keys.endIndex
+    }
+
+    /// - Returns: Element at the given `index`.
+    public subscript (index: Int) -> (key: Key, value: Value) {
+        let key = keys[index]
+        let value = unordered[key]!
+        return (key,value)
+    }
+}
+
+extension OrderedDictionary: Equatable where Value: Equatable { }
+extension OrderedDictionary: Hashable where Value: Hashable { }
+
+extension OrderedDictionary: ExpressibleByDictionaryLiteral {
+
+    // MARK: - ExpressibleByDictionaryLiteral
+
+    /// Create an `OrderedDictionary` with a `DictionaryLiteral`.
+    public init(dictionaryLiteral elements: (Key,Value)...) {
+        self.init(minimumCapacity: elements.count)
+        elements.forEach { (k,v) in append(v, key: k) }
+    }
+}
+
+extension OrderedDictionary: CustomStringConvertible {
+
+    // MARK: - CustomStringConvertible
+
+    /// - Returns: A string that represents the contents of the `OrderedDictionary`.
+    public var description: String {
+        if self.count == 0 { return "[:]" }
+        var result = "["
+        var first = true
+        for (key,value) in self {
+            if first {
+                first = false
+            } else {
+                result += ", "
+            }
+            debugPrint(key, terminator: "", to: &result)
+            result += ": "
+            debugPrint(value, terminator: "", to: &result)
+        }
+        result += "]"
+        return result
+    }
+}
+
+extension Array where Element: Equatable {
+    /// - Returns: An array of values with no duplicate values.
+    func removingDuplicates() -> Array {
+        var result: Array = []
+        for element in self where !result.contains(element) {
+            result.append(element)
+        }
+        return result
+    }
+}

--- a/Tests/XMLCoderTests/Auxiliary/OrderedDictionaryTests.swift
+++ b/Tests/XMLCoderTests/Auxiliary/OrderedDictionaryTests.swift
@@ -74,6 +74,38 @@ class OrderedDictionaryTests: XCTestCase {
         XCTAssertEqual(dict[1].value, "anotherVal")
     }
 
+    func testMapValues() {
+        let dict: OrderedDictionary = ["0": 0, "1": 1, "2": 2, "3": 3]
+        let result = dict.mapValues { $0 * 2 }
+        let expected: OrderedDictionary = ["0": 0, "1": 2, "2": 4, "3": 6]
+        XCTAssertEqual(result, expected)
+    }
+
+    func testSorted() {
+        let dict: OrderedDictionary = ["0": 0, "1": 1, "2": 2, "3": 3]
+        let sorted = dict.sorted(by: { (a,b) in a.value > b.value })
+        let expected: OrderedDictionary = ["3": 3, "2": 2, "1": 1, "0": 0]
+        XCTAssertEqual(sorted, expected)
+    }
+
+    func testKeySubscriptNewValue() {
+        var dict: OrderedDictionary = ["0": 0, "1": 1, "2": 2, "3": 3]
+        dict["4"] = 4
+        XCTAssertEqual(dict, ["0": 0, "1": 1, "2": 2, "3": 3, "4": 4])
+    }
+
+    func testKeySubscriptReplaceValue() {
+        var dict: OrderedDictionary = ["0": 0, "1": 1, "2": 2, "3": 3]
+        dict["0"] = 42
+        XCTAssertEqual(dict, ["0": 42, "1": 1, "2": 2, "3": 3])
+    }
+
+    func testKeySubscriptNil() {
+        var dict: OrderedDictionary = ["0": 0, "1": 1, "2": 2, "3": 3]
+        dict["0"] = nil
+        XCTAssertEqual(dict, ["1": 1, "2": 2, "3": 3])
+    }
+
     func testIterationOrdered() {
         var dict = OrderedDictionary<Int, String>()
         dict[1] = "one"
@@ -91,4 +123,20 @@ class OrderedDictionaryTests: XCTestCase {
         XCTAssertEqual(a,b)
     }
 
+    func testEquatableUnequal() {
+        let a: OrderedDictionary = [1: "one", 2: "two", 3: "three"]
+        let b: OrderedDictionary = [1: "one", 2: "two", 42: "forty-two"]
+        XCTAssertNotEqual(a,b)
+    }
+
+    func testDescription() {
+        let dict: OrderedDictionary = ["0": 0, "1": 1, "2": 2, "3": 3]
+        let expected = "[\"0\": 0, \"1\": 1, \"2\": 2, \"3\": 3]"
+        XCTAssertEqual(dict.description, expected)
+    }
+
+    func testDescriptionEmpty() {
+        let dict: OrderedDictionary<String,Int> = [:]
+        XCTAssertEqual(dict.description, "[:]")
+    }
 }

--- a/Tests/XMLCoderTests/Auxiliary/OrderedDictionaryTests.swift
+++ b/Tests/XMLCoderTests/Auxiliary/OrderedDictionaryTests.swift
@@ -1,0 +1,94 @@
+//
+//  OrderedDictionaryTests.swift
+//  XMLCoderTests
+//
+//  Created by James Bean on 12/22/18.
+//
+
+import XCTest
+@testable import XMLCoder
+
+class OrderedDictionaryTests: XCTestCase {
+
+    func testInitKeysAndUnordered() {
+        let dict = OrderedDictionary(
+            keys: ["zero", "one", "two"],
+            unordered: ["one": 1, "two": 2, "zero": 0]
+        )
+        let expected: OrderedDictionary = ["zero": 0, "one": 1, "two": 2]
+        XCTAssertEqual(dict, expected)
+    }
+
+    func testInitUnordered() {
+        let unordered = ["one": 1, "two": 2, "zero": 0]
+        let dict = OrderedDictionary(unordered)
+        XCTAssertEqual(Set(unordered.keys), Set(dict.keys))
+        XCTAssertEqual(Set(unordered.values), Set(dict.values))
+    }
+
+    func testInitUniqueKeysWithValues() {
+        let dict = OrderedDictionary(uniqueKeysWithValues: [("zero",0), ("one",1), ("two",2)])
+        let expected: OrderedDictionary = ["zero": 0, "one": 1, "two": 2]
+        XCTAssertEqual(dict, expected)
+    }
+
+    func testInitKeysAndValuesUniquingKeysWith() {
+        let dict = OrderedDictionary(
+            [("zero", 42), ("zero", 0), ("one",1),("two",2)],
+            uniquingKeysWith: { a,b in b }
+        )
+        let expected: OrderedDictionary = ["zero": 0, "one": 1, "two": 2]
+        XCTAssertEqual(dict, expected)
+    }
+
+    func testSubscriptKeyNil() {
+        let dict: OrderedDictionary<String,Int> = [:]
+        XCTAssertNil(dict["zero"])
+    }
+
+    func testSubscriptInt() {
+        var dict = OrderedDictionary<String,String>()
+        dict.insert("val", key: "key", index: 0)
+        XCTAssertEqual(dict[0].value, "val")
+    }
+
+    func testSubscriptKeyValid() {
+        var dict = OrderedDictionary<String,String>()
+        dict.insert("val", key: "key", index: 0)
+        XCTAssertEqual(dict["key"]!, "val")
+    }
+
+    func testInsert() {
+        var dict = OrderedDictionary<String, String>()
+        dict.insert("val", key: "key", index: 0)
+        dict.insert("insertedVal", key: "insertedKey", index: 0)
+        XCTAssertEqual(dict[0].value, "insertedVal")
+        XCTAssertEqual(dict[1].value, "val")
+    }
+
+    func testAppend() {
+        var dict = OrderedDictionary<String, String>()
+        dict.append("val", key: "key")
+        dict.append("anotherVal", key: "anotherKey")
+        XCTAssertEqual(dict[0].value, "val")
+        XCTAssertEqual(dict[1].value, "anotherVal")
+    }
+
+    func testIterationOrdered() {
+        var dict = OrderedDictionary<Int, String>()
+        dict[1] = "one"
+        dict[2] = "two"
+        dict[3] = "three"
+        dict[4] = "four"
+        dict[5] = "five"
+        XCTAssertEqual(dict.map { $0.0 }, [1, 2, 3, 4, 5])
+        XCTAssertEqual(dict.map { $0.1 }, ["one", "two", "three", "four", "five"])
+    }
+
+    func testEquatable() {
+        let a: OrderedDictionary = [1: "one", 2: "two", 3: "three"]
+        let b: OrderedDictionary = [1: "one", 2: "two", 3: "three"]
+        XCTAssertEqual(a,b)
+    }
+
+}

--- a/XMLCoder.xcodeproj/project.pbxproj
+++ b/XMLCoder.xcodeproj/project.pbxproj
@@ -21,6 +21,8 @@
 /* End PBXAggregateTarget section */
 
 /* Begin PBXBuildFile section */
+		072C52BE21CECC7E00C95410 /* OrderedDictionary.swift in Sources */ = {isa = PBXBuildFile; fileRef = 072C52BD21CECC7E00C95410 /* OrderedDictionary.swift */; };
+		072C52C021CED1FC00C95410 /* OrderedDictionaryTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 072C52BF21CED1FC00C95410 /* OrderedDictionaryTests.swift */; };
 		BF63EF0021CCDED2001D38C5 /* XMLStackParserTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = BF63EEFF21CCDED2001D38C5 /* XMLStackParserTests.swift */; };
 		BF63EF0621CD7A74001D38C5 /* URLBox.swift in Sources */ = {isa = PBXBuildFile; fileRef = BF63EF0521CD7A74001D38C5 /* URLBox.swift */; };
 		BF63EF0821CD7AF8001D38C5 /* URLBoxTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = BF63EF0721CD7AF8001D38C5 /* URLBoxTests.swift */; };
@@ -110,6 +112,8 @@
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXFileReference section */
+		072C52BD21CECC7E00C95410 /* OrderedDictionary.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OrderedDictionary.swift; sourceTree = "<group>"; };
+		072C52BF21CED1FC00C95410 /* OrderedDictionaryTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OrderedDictionaryTests.swift; sourceTree = "<group>"; };
 		BF63EEFF21CCDED2001D38C5 /* XMLStackParserTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = XMLStackParserTests.swift; sourceTree = "<group>"; };
 		BF63EF0521CD7A74001D38C5 /* URLBox.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = URLBox.swift; sourceTree = "<group>"; };
 		BF63EF0721CD7AF8001D38C5 /* URLBoxTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = URLBoxTests.swift; sourceTree = "<group>"; };
@@ -206,6 +210,7 @@
 			isa = PBXGroup;
 			children = (
 				BF63EEFF21CCDED2001D38C5 /* XMLStackParserTests.swift */,
+				072C52BF21CED1FC00C95410 /* OrderedDictionaryTests.swift */,
 			);
 			path = Auxiliary;
 			sourceTree = "<group>";
@@ -234,6 +239,7 @@
 			isa = PBXGroup;
 			children = (
 				BF9457B121CBB4DB005ACFDE /* XMLHeader.swift */,
+				072C52BD21CECC7E00C95410 /* OrderedDictionary.swift */,
 				BF9457B221CBB4DB005ACFDE /* String+Extensions.swift */,
 				BF9457B321CBB4DB005ACFDE /* XMLStackParser.swift */,
 				BF9457B421CBB4DB005ACFDE /* ISO8601DateFormatter.swift */,
@@ -478,6 +484,7 @@
 				OBJ_54 /* XMLEncoder.swift in Sources */,
 				BF9457BA21CBB4DB005ACFDE /* ISO8601DateFormatter.swift in Sources */,
 				OBJ_55 /* XMLEncodingStorage.swift in Sources */,
+				072C52BE21CECC7E00C95410 /* OrderedDictionary.swift in Sources */,
 				BF9457A921CBB498005ACFDE /* KeyedBox.swift in Sources */,
 				BF9457D721CBB59E005ACFDE /* IntBox.swift in Sources */,
 				BF9457AD21CBB498005ACFDE /* BoolBox.swift in Sources */,
@@ -528,6 +535,7 @@
 				OBJ_83 /* CDTest.swift in Sources */,
 				OBJ_85 /* NodeEncodingStrategyTests.swift in Sources */,
 				OBJ_86 /* NoteTest.swift in Sources */,
+				072C52C021CED1FC00C95410 /* OrderedDictionaryTests.swift in Sources */,
 				BF63EF0C21CD7F28001D38C5 /* EmptyTests.swift in Sources */,
 				BF9457F721CBB6BC005ACFDE /* DataTests.swift in Sources */,
 				BF9457EE21CBB6BC005ACFDE /* IntTests.swift in Sources */,

--- a/XMLCoder.xcodeproj/xcshareddata/xcschemes/XMLCoder.xcscheme
+++ b/XMLCoder.xcodeproj/xcshareddata/xcschemes/XMLCoder.xcscheme
@@ -14,7 +14,7 @@
             buildForAnalyzing = "YES">
             <BuildableReference
                BuildableIdentifier = "primary"
-               BlueprintIdentifier = "XMLParsing::XMLParsing"
+               BlueprintIdentifier = "XMLCoder::XMLCoder"
                BuildableName = "XMLCoder.framework"
                BlueprintName = "XMLCoder"
                ReferencedContainer = "container:XMLCoder.xcodeproj">
@@ -26,13 +26,14 @@
       buildConfiguration = "Debug"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      codeCoverageEnabled = "YES"
       shouldUseLaunchSchemeArgsEnv = "YES">
       <Testables>
          <TestableReference
             skipped = "NO">
             <BuildableReference
                BuildableIdentifier = "primary"
-               BlueprintIdentifier = "XMLParsing::XMLParsingTests"
+               BlueprintIdentifier = "XMLCoder::XMLCoderTests"
                BuildableName = "XMLCoderTests.xctest"
                BlueprintName = "XMLCoderTests"
                ReferencedContainer = "container:XMLCoder.xcodeproj">
@@ -55,7 +56,7 @@
       <MacroExpansion>
          <BuildableReference
             BuildableIdentifier = "primary"
-            BlueprintIdentifier = "XMLParsing::XMLParsing"
+            BlueprintIdentifier = "XMLCoder::XMLCoder"
             BuildableName = "XMLCoder.framework"
             BlueprintName = "XMLCoder"
             ReferencedContainer = "container:XMLCoder.xcodeproj">


### PR DESCRIPTION
This PR adds an `OrderedDictionary` structure to the project, though does not use it for anything yet.

This should be useful for maintaining order of ~~attributes~~ elements (#17), and was useful in an experimental outing to solve #25, and I can imagine it being useful for #12, as well.

I thought I'd propose this here to start some conversation about these issues and how to approach solving them. If this won't be of help, feel free to close!