### PR TITLE
Install Carthage only in before_deploy on Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,12 +7,12 @@ before_install:
 - gem install cocoapods --pre # Since Travis is not always on latest version
 - brew update
 - brew install swiftformat
-- brew outdated carthage || brew upgrade carthage
 script:
 - swiftformat --lint --verbose .
 - pod lib lint
 - xcodebuild test -enableCodeCoverage YES -scheme XMLCoder
 before_deploy:
+- brew outdated carthage || brew upgrade carthage
 - carthage build --no-skip-current
 - carthage archive $FRAMEWORK_NAME
 after_success:


### PR DESCRIPTION
This should slightly decrease Travis build time for builds running from untagged commits.