### PR TITLE
Fix `KeyDecodingStrategy.custom` signature

### DIFF
--- a/Sources/XMLCoder/Decoder/XMLDecoder.swift
+++ b/Sources/XMLCoder/Decoder/XMLDecoder.swift
@@ -137,9 +137,9 @@ open class XMLDecoder {
         case convertFromCapitalized
 
         /// Provide a custom conversion from the key in the encoded XML to the keys specified by the decoded types.
-        /// The full path to the current decoding position is provided for context (in case you need to locate this key within the payload). The returned key is used in place of the last component in the coding path before decoding.
+        /// The returned key is used in place of the last component in the coding path before decoding.
         /// If the result of the conversion is a duplicate key, then only one box will be present in the container for the type to decode from.
-        case custom((_ codingPath: [CodingKey]) -> CodingKey)
+        case custom((_ codingPath: String) -> String)
 
         static func _convertFromCapitalized(_ stringKey: String) -> String {
             guard !stringKey.isEmpty else {

--- a/Sources/XMLCoder/Decoder/XMLDecoder.swift
+++ b/Sources/XMLCoder/Decoder/XMLDecoder.swift
@@ -139,7 +139,7 @@ open class XMLDecoder {
         /// Provide a custom conversion from the key in the encoded XML to the keys specified by the decoded types.
         /// The returned key is used in place of the last component in the coding path before decoding.
         /// If the result of the conversion is a duplicate key, then only one box will be present in the container for the type to decode from.
-        case custom((_ codingPath: String) -> String)
+        case custom((_ stringKey: String) -> String)
 
         static func _convertFromCapitalized(_ stringKey: String) -> String {
             guard !stringKey.isEmpty else {

--- a/Sources/XMLCoder/Decoder/XMLKeyedDecodingContainer.swift
+++ b/Sources/XMLCoder/Decoder/XMLKeyedDecodingContainer.swift
@@ -53,14 +53,10 @@ struct _XMLKeyedDecodingContainer<K: CodingKey>: KeyedDecodingContainerProtocol 
             self.container = KeyedBox(elements: elements, attributes: attributes)
         case let .custom(converter):
             let attributes = container.attributes.map { key, value in
-                (converter(decoder.codingPath +
-                     [_XMLKey(stringValue: key, intValue: nil)]).stringValue,
-                 value)
+                (converter(key), value)
             }
             let elements = container.elements.map { key, value in
-                (converter(decoder.codingPath +
-                     [_XMLKey(stringValue: key, intValue: nil)]).stringValue,
-                 value)
+                (converter(key), value)
             }
             self.container = KeyedBox(elements: elements, attributes: attributes)
         }


### PR DESCRIPTION
When trying to provide test coverage for `KeyDecodingStrategy.custom` we've stumbled upon an API, which doesn't make much sense. The [corresponding case for JSONDecoder](https://developer.apple.com/documentation/foundation/jsondecoder/keydecodingstrategy/custom) involves creation of a dummy `AnyKey` structure to return a new synthesised coding key, which isn't guaranteed to match a coding key of the decoded type. It's also unclear how `intValue` of this dummy structure could be used.

All other cases of `KeyDecodingStrategy` delegate to functions with `String -> String` signature and my opinion this is the main application of `KeyDecodingStrategy.custom`: convert string keys to other string keys with a supplied transformation.

This is a breaking change though, so I'm still a bit unsure whether we should follow `JSONDecoder` or rely on common sense with this.

@regexident could you please provide your feedback, maybe you had some experience with this? Thanks.