### PR TITLE
Specify Swift version for packaging, refine CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,6 +11,11 @@ script:
 - swiftformat --lint --verbose .
 - pod lib lint
 - xcodebuild test -enableCodeCoverage YES -scheme XMLCoder
+# this runs the tests the second time, but it's the only way to make sure
+# that `Package.swift` is in a good state and `swift test` can only generate
+# coverage reports in Swift 5.0, see this issue for more details:
+# https://github.com/apple/swift-package-manager/pull/1787
+- swift test
 before_deploy:
 - brew outdated carthage || brew upgrade carthage
 - carthage build --no-skip-current

--- a/Package.swift
+++ b/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version:4.0
+// swift-tools-version:4.2
 // The swift-tools-version declares the minimum version of Swift required to build this package.
 
 import PackageDescription

--- a/XMLCoder.podspec
+++ b/XMLCoder.podspec
@@ -1,16 +1,17 @@
 Pod::Spec.new do |s|
-  s.name         = "XMLCoder"
-  s.version      = "0.2.1"
-  s.summary      = "XMLEncoder & XMLDecoder using the Codable protocol in Swift 4"
-  s.description  = "XMLCoder allows Swift 4 Codable-conforming objects to be translated to and from XML"
-  s.homepage     = "https://github.com/MaxDesiatov/XMLCoder"
-  s.license      = { :type => "MIT", :file => "LICENSE" }
-  s.author       = { "Shawn Moore" => "sm5@me.com" }
+  s.name          = "XMLCoder"
+  s.version       = "0.2.1"
+  s.summary       = "XMLEncoder & XMLDecoder using the Codable protocol in Swift 4"
+  s.description   = "XMLCoder allows Swift 4 Codable-conforming objects to be translated to and from XML"
+  s.homepage      = "https://github.com/MaxDesiatov/XMLCoder"
+  s.license       = { :type => "MIT", :file => "LICENSE" }
+  s.author        = { "Shawn Moore" => "sm5@me.com" }
   s.watchos.deployment_target = "2.0"
   s.ios.deployment_target = "9.0"
   s.tvos.deployment_target = "9.0"
   s.osx.deployment_target = "10.11"
-  s.source       = { :git => "https://github.com/MaxDesiatov/XMLCoder.git", :tag => s.version.to_s }
-  s.source_files = "Sources/XMLCoder/**/*.swift"
-  s.requires_arc = true
+  s.swift_version = "4.2"
+  s.source        = { :git => "https://github.com/MaxDesiatov/XMLCoder.git", :tag => s.version.to_s }
+  s.source_files  = "Sources/XMLCoder/**/*.swift"
+  s.requires_arc  = true
 end


### PR DESCRIPTION
This sets version to 4.2 for both SwiftPM and CocoaPods. A `swift test` run has been added to `.travis.yml`, which makes CI builds longer, but looks like it's the only way to make sure SwiftPM builds work and generate code coverage at the same time.

Resolves #57