### PR TITLE
Fix compatibility with Swift 5.0

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -27,5 +27,6 @@ let package = Package(
             name: "XMLCoderTests",
             dependencies: ["XMLCoder"]
         ),
-    ]
+    ],
+    swiftLanguageVersions: [.v4_2, .version("5")]
 )

--- a/Sources/XMLCoder/Decoder/XMLDecoder.swift
+++ b/Sources/XMLCoder/Decoder/XMLDecoder.swift
@@ -178,7 +178,7 @@ open class XMLDecoder {
             }
 
             // Find the first non-underscore character
-            guard let firstNonUnderscore = stringKey.index(where: { $0 != "_" }) else {
+            guard let firstNonUnderscore = stringKey.firstIndex(where: { $0 != "_" }) else {
                 // Reached the end without finding an _
                 return stringKey
             }

--- a/Sources/XMLCoder/Decoder/XMLDecoderImplementation.swift
+++ b/Sources/XMLCoder/Decoder/XMLDecoderImplementation.swift
@@ -308,7 +308,6 @@ extension XMLDecoderImplementation {
 
         if type == Date.self || type == NSDate.self {
             let date: Date = try unbox(box)
-
             decoded = date as? T
         } else if type == Data.self || type == NSData.self {
             let data: Data = try unbox(box)
@@ -321,7 +320,7 @@ extension XMLDecoderImplementation {
             decoded = decimal as? T
         } else if
             type == String.self || type == NSString.self,
-            let str: String = try? unbox(box), let value = str as? T {
+            let value = (try unbox(box) as String) as? T {
             decoded = value
         } else {
             storage.push(container: box)

--- a/Tests/XMLCoderTests/DynamicNodeEncodingTest.swift
+++ b/Tests/XMLCoderTests/DynamicNodeEncodingTest.swift
@@ -125,8 +125,6 @@ final class DynamicNodeEncodingTest: XCTestCase {
         let header = XMLHeader(version: 1.0, encoding: "UTF-8")
         let encoded = try encoder.encode(library, withRootKey: "library", header: header)
         let xmlString = String(data: encoded, encoding: .utf8)
-        print(xmlString!)
-        print(libraryXMLTrueFalse)
         XCTAssertEqual(xmlString, libraryXMLTrueFalse)
     }
 
@@ -197,7 +195,6 @@ final class DynamicNodeEncodingTest: XCTestCase {
         let data = try encoder.encode(library, withRootKey: "library",
                                       header: XMLHeader(version: 1.0,
                                                         encoding: "UTF-8"))
-        print(String(data: data, encoding: .utf8)!)
         let library2 = try decoder.decode(Library.self, from: data)
         XCTAssertEqual(library, library2)
     }


### PR DESCRIPTION
When XMLCoder is compiled in Swift 5.0 mode it causes infinite loops in some tests, apparently due to change in `try?` behaviour introduced in [SE-0230](https://github.com/apple/swift-evolution/blob/master/proposals/0230-flatten-optional-try.md). In generic `unbox` handling of the `String` case with `try? unbox(box)` is always inferred as a call to `unbox<String?>` instead of a call to `unbox<String>`, as it was in Swift 4.2 mode. This is now fixed with rearranged type hints in this call. Also applied Swift 5.0 migrator suggestion to change `index` to `firstIndex`.