### PR TITLE
Fix nested attributed intrinsic

### DIFF
--- a/Sources/XMLCoder/Auxiliaries/XMLCoderElement.swift
+++ b/Sources/XMLCoder/Auxiliaries/XMLCoderElement.swift
@@ -44,6 +44,8 @@ struct XMLCoderElement: Equatable {
         elements.append(element)
     }
 
+    // FIXME: this should be split into separate functions and
+    // thoroughtly tested
     func flatten() -> KeyedBox {
         let attributes = self.attributes.mapValues { StringBox($0) }
 
@@ -73,7 +75,7 @@ struct XMLCoderElement: Equatable {
                     case var unkeyedBox as UnkeyedBox:
                         unkeyedBox.append(content)
                         result[key] = unkeyedBox
-                    case let box?:
+                    case let box? where !hasValue:
                         result[key] = UnkeyedBox([box, content])
                     default:
                         result[key] = content

--- a/Tests/XMLCoderTests/AttributedIntrinsicTest.swift
+++ b/Tests/XMLCoderTests/AttributedIntrinsicTest.swift
@@ -52,6 +52,45 @@ private struct FooEmptyKeyed: Codable, DynamicNodeEncoding {
     }
 }
 
+private let previewXML =
+    """
+    <?xml version="1.0" encoding="UTF-8"?>
+    <app_preview display_target="iOS-6.5-in" position="1">
+    <preview_image_time format="24/999 1000/nonDrop">00:00:17:01</preview_image_time>
+    </app_preview>
+    """.data(using: .utf8)!
+
+private struct AppPreview: Codable {
+    var displayTarget: String
+    var position: Int
+    var previewImageTime: PreviewImageTime
+
+    enum CodingKeys: String, CodingKey {
+        case displayTarget = "display_target"
+        case position
+        case previewImageTime = "preview_image_time"
+    }
+}
+
+private struct PreviewImageTime: Codable, DynamicNodeEncoding {
+    var format: String
+    var value: String
+
+    enum CodingKeys: String, CodingKey {
+        case format
+        case value
+    }
+
+    static func nodeEncoding(forKey key: CodingKey) -> XMLEncoder.NodeEncoding {
+        switch key {
+        case CodingKeys.format:
+            return .attribute
+        default:
+            return .element
+        }
+    }
+}
+
 final class AttributedIntrinsicTest: XCTestCase {
     func testEncode() throws {
         let encoder = XMLEncoder()
@@ -83,9 +122,17 @@ final class AttributedIntrinsicTest: XCTestCase {
         XCTAssertEqual(foo2.unkeyedValue, 456)
     }
 
+    func testDecodePreview() throws {
+        let decoder = XMLDecoder()
+
+        let preview = try decoder.decode(AppPreview.self, from: previewXML)
+        print(preview)
+    }
+
     static var allTests = [
         ("testEncode", testEncode),
         ("testDecode", testDecode),
+        ("testDecodePreview", testDecodePreview),
     ]
 }
 

--- a/Tests/XMLCoderTests/AttributedIntrinsicTest.swift
+++ b/Tests/XMLCoderTests/AttributedIntrinsicTest.swift
@@ -60,7 +60,7 @@ private let previewXML =
     </app_preview>
     """.data(using: .utf8)!
 
-private struct AppPreview: Codable {
+private struct AppPreview: Codable, Equatable {
     var displayTarget: String
     var position: Int
     var previewImageTime: PreviewImageTime
@@ -72,7 +72,7 @@ private struct AppPreview: Codable {
     }
 }
 
-private struct PreviewImageTime: Codable, DynamicNodeEncoding {
+private struct PreviewImageTime: Codable, Equatable, DynamicNodeEncoding {
     var format: String
     var value: String
 
@@ -126,7 +126,14 @@ final class AttributedIntrinsicTest: XCTestCase {
         let decoder = XMLDecoder()
 
         let preview = try decoder.decode(AppPreview.self, from: previewXML)
-        print(preview)
+        XCTAssertEqual(AppPreview(
+            displayTarget: "iOS-6.5-in",
+            position: 1,
+            previewImageTime: PreviewImageTime(
+                format: "24/999 1000/nonDrop",
+                value: "00:00:17:01"
+            )
+        ), preview)
     }
 
     static var allTests = [


### PR DESCRIPTION
Existing `flatten` implementation wasn't correctly handling element values, this is now fixed.

Fixes #78 