### PR TITLE
Add separate lint stage to .travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,17 +1,3 @@
-jobs:
-  include:
-  - stage: lint
-    before_install:
-    - brew update
-    - brew install swiftformat
-    - brew outdated swiftlint || brew upgrade swiftlint
-    script:
-    - swiftformat --lint --verbose .
-    - swiftlint
-    - pod lib lint --verbose
-    osx_image: xcode10.2
-    language: swift
-
 matrix:
   include:
   - osx_image: xcode10
@@ -38,6 +24,20 @@ matrix:
       on:
         repo: MaxDesiatov/XMLCoder
         tags: true
+
+jobs:
+  include:
+  - stage: lint
+    before_install:
+    - brew update
+    - brew install swiftformat
+    - brew outdated swiftlint || brew upgrade swiftlint
+    script:
+    - swiftformat --lint --verbose .
+    - swiftlint
+    - pod lib lint --verbose
+    osx_image: xcode10.2
+    language: swift
 
 env:
   global:

--- a/.travis.yml
+++ b/.travis.yml
@@ -34,19 +34,22 @@ env:
 
 jobs:
   include:
-  - stage: unit-test
-  script:
-  - >
-    xcodebuild test -enableCodeCoverage YES -scheme XMLCoder
-    -sdk iphonesimulator -destination "$TEST_DEVICE" | xcpretty
-  - >
-    xcodebuild test -enableCodeCoverage YES -scheme XMLCoder 
-    -sdk macosx | xcpretty
-  # this runs the tests the second time, but it's the only way to make sure
-  # that `Package.swift` is in a good state and `swift test` can only generate
-  # coverage reports in Swift 5.0, see this issue for more details:
-  # https://github.com/apple/swift-package-manager/pull/1787
-  - swift test
+  - &unit-test
+    stage: unit-test
+    osx_image: xcode10
+    language: swift
+    script:
+      - >
+        xcodebuild test -enableCodeCoverage YES -scheme XMLCoder
+        -sdk iphonesimulator -destination "$TEST_DEVICE" | xcpretty
+      - >
+        xcodebuild test -enableCodeCoverage YES -scheme XMLCoder 
+        -sdk macosx | xcpretty
+      # this runs the tests the second time, but it's the only way to make sure
+      # that `Package.swift` is in a good state and `swift test` can only generate
+      # coverage reports in Swift 5.0, see this issue for more details:
+      # https://github.com/apple/swift-package-manager/pull/1787
+      - swift test
 
 before_install:
 - brew update

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,52 +11,52 @@ jobs:
     - swiftformat --lint --verbose .
     - swiftlint
     - pod lib lint --verbose
-  - stage: test
-    osx_image: xcode10
-    language: swift
-    env: TEST_DEVICE='platform=iOS Simulator,OS=12.0,name=iPhone SE'
-    script:
-    - >
-      xcodebuild test -enableCodeCoverage YES -scheme XMLCoder
-      -sdk iphonesimulator -destination "$TEST_DEVICE" | xcpretty
-    - >
-      xcodebuild test -enableCodeCoverage YES -scheme XMLCoder 
-      -sdk macosx | xcpretty
-  - script:
-    - >
-      xcodebuild test -enableCodeCoverage YES -scheme XMLCoder
-      -sdk iphonesimulator -destination "$TEST_DEVICE" | xcpretty
-    - >
-      xcodebuild test -enableCodeCoverage YES -scheme XMLCoder 
-      -sdk macosx | xcpretty
-    osx_image: xcode10.1
-    language: swift
-    env: TEST_DEVICE='platform=iOS Simulator,OS=12.1,name=iPhone SE'
-  - script:
-    - >
-      xcodebuild test -enableCodeCoverage YES -scheme XMLCoder
-      -sdk iphonesimulator -destination "$TEST_DEVICE" | xcpretty
-    - >
-      xcodebuild test -enableCodeCoverage YES -scheme XMLCoder 
-      -sdk macosx | xcpretty
-    osx_image: xcode10.2
-    language: swift
-    env: TEST_DEVICE='platform=iOS Simulator,OS=12.2,name=iPhone SE'
-    after_success:
-    - bash <(curl -s https://codecov.io/bash)
-    before_deploy:
-    - brew outdated carthage || brew upgrade carthage
-    - carthage build --no-skip-current
-    - carthage archive $FRAMEWORK_NAME
-    deploy:
-      provider: releases
-      api_key:
-        secure: yACVlrO+oqAPJ7NS2N2Cut8eCTO0yWWKuV9510tpwmsCKuHUJZ9fT1Z4zhteghGiDZJzZHzMteSK3YPHeCFBbZJAq95HeWV8ki0Cs+7tL8jO0U1zniilb/vk4MvT3z7QdzueXO+DHBw9nbszARwbfgBAWhkPbt9zKwk882Hoke5M9mfbQ9kUHNH+jTV5R7FdtkbkGpo1zzEglYZT0IshLTbBSlBjqEu9kJSJxTQjciKu6f/DvDYgV0AyXqi96hlmaSrTE9vM6bRxbN+t9QNAtlXxlB4mGiprKR8et1MFJHR9ECIpbzfsAWzehPtSksfXLgAfq0z0fIR3RRN4w76oMgAQcBS1xPnDFXjyMDv+QJHfXcGsACubU10FxZDHinF3odRzzAuQI2mxcvFJ7rcPVpe/Y1M1otxyRAlj3AE3yMp3eoTqoByjym/ckBSs9Ui5kgWIaQPtaGx6HkFFGjZlbxkNLcd6cQjrhAOUVF0FjABcdOi0ZM1HpBusdcdEx4aA68XcrZvWi9zWeG9rHb9Z20hJKme/zkuiAbKtwDFJ3y+WiQK27JtKTgz4VtDbtiWpjaj1Uw8FhbE/X+9fuN09HSfN5n/NDuIoDJtyAxBkalxGMggeWWHCb6vjYk9+jubyOYctGBh4jbRuSp2QMdR62GlghVa0ARSGiQOOWGEk6LU=
-      file: "$FRAMEWORK_NAME.framework.zip"
-      skip_cleanup: true
-      on:
-        repo: MaxDesiatov/XMLCoder
-        tags: true
+  # - stage: test
+  #   osx_image: xcode10
+  #   language: swift
+  #   env: TEST_DEVICE='platform=iOS Simulator,OS=12.0,name=iPhone SE'
+  #   script:
+  #   - >
+  #     xcodebuild test -enableCodeCoverage YES -scheme XMLCoder
+  #     -sdk iphonesimulator -destination "$TEST_DEVICE" | xcpretty
+  #   - >
+  #     xcodebuild test -enableCodeCoverage YES -scheme XMLCoder 
+  #     -sdk macosx | xcpretty
+  # - script:
+  #   - >
+  #     xcodebuild test -enableCodeCoverage YES -scheme XMLCoder
+  #     -sdk iphonesimulator -destination "$TEST_DEVICE" | xcpretty
+  #   - >
+  #     xcodebuild test -enableCodeCoverage YES -scheme XMLCoder 
+  #     -sdk macosx | xcpretty
+  #   osx_image: xcode10.1
+  #   language: swift
+  #   env: TEST_DEVICE='platform=iOS Simulator,OS=12.1,name=iPhone SE'
+  # - script:
+  #   - >
+  #     xcodebuild test -enableCodeCoverage YES -scheme XMLCoder
+  #     -sdk iphonesimulator -destination "$TEST_DEVICE" | xcpretty
+  #   - >
+  #     xcodebuild test -enableCodeCoverage YES -scheme XMLCoder 
+  #     -sdk macosx | xcpretty
+  #   osx_image: xcode10.2
+  #   language: swift
+  #   env: TEST_DEVICE='platform=iOS Simulator,OS=12.2,name=iPhone SE'
+  #   after_success:
+  #   - bash <(curl -s https://codecov.io/bash)
+  #   before_deploy:
+  #   - brew outdated carthage || brew upgrade carthage
+  #   - carthage build --no-skip-current
+  #   - carthage archive $FRAMEWORK_NAME
+  #   deploy:
+  #     provider: releases
+  #     api_key:
+  #       secure: yACVlrO+oqAPJ7NS2N2Cut8eCTO0yWWKuV9510tpwmsCKuHUJZ9fT1Z4zhteghGiDZJzZHzMteSK3YPHeCFBbZJAq95HeWV8ki0Cs+7tL8jO0U1zniilb/vk4MvT3z7QdzueXO+DHBw9nbszARwbfgBAWhkPbt9zKwk882Hoke5M9mfbQ9kUHNH+jTV5R7FdtkbkGpo1zzEglYZT0IshLTbBSlBjqEu9kJSJxTQjciKu6f/DvDYgV0AyXqi96hlmaSrTE9vM6bRxbN+t9QNAtlXxlB4mGiprKR8et1MFJHR9ECIpbzfsAWzehPtSksfXLgAfq0z0fIR3RRN4w76oMgAQcBS1xPnDFXjyMDv+QJHfXcGsACubU10FxZDHinF3odRzzAuQI2mxcvFJ7rcPVpe/Y1M1otxyRAlj3AE3yMp3eoTqoByjym/ckBSs9Ui5kgWIaQPtaGx6HkFFGjZlbxkNLcd6cQjrhAOUVF0FjABcdOi0ZM1HpBusdcdEx4aA68XcrZvWi9zWeG9rHb9Z20hJKme/zkuiAbKtwDFJ3y+WiQK27JtKTgz4VtDbtiWpjaj1Uw8FhbE/X+9fuN09HSfN5n/NDuIoDJtyAxBkalxGMggeWWHCb6vjYk9+jubyOYctGBh4jbRuSp2QMdR62GlghVa0ARSGiQOOWGEk6LU=
+  #     file: "$FRAMEWORK_NAME.framework.zip"
+  #     skip_cleanup: true
+  #     on:
+  #       repo: MaxDesiatov/XMLCoder
+  #       tags: true
 
 env:
   global:

--- a/.travis.yml
+++ b/.travis.yml
@@ -32,6 +32,15 @@ env:
 #         repo: MaxDesiatov/XMLCoder
 #         tags: true
 
+before_install:
+  - brew update
+  - brew install swiftformat
+  - brew outdated swiftlint || brew upgrade swiftlint
+script:
+  - swiftformat --lint --verbose .
+  - swiftlint
+  - pod lib lint --verbose
+
 jobs:
   include:
   - &unit-test
@@ -50,15 +59,6 @@ jobs:
       # coverage reports in Swift 5.0, see this issue for more details:
       # https://github.com/apple/swift-package-manager/pull/1787
       - swift test
-
-before_install:
-- brew update
-- brew install swiftformat
-- brew outdated swiftlint || brew upgrade swiftlint
-script:
-- swiftformat --lint --verbose .
-- swiftlint
-- pod lib lint --verbose
 
 # this is commented because installing Jazzy on Travis doesn't work ¯\_(ツ)_/¯ 
 # - ./docs.sh

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,72 +1,61 @@
-jobs:
-  include:
-  - stage: lint
-    osx_image: xcode10.2
-    language: swift
-    before_install:
-    - brew update
-    - brew install swiftformat
-    - brew outdated swiftlint || brew upgrade swiftlint
-    script:
-    - swiftformat --lint --verbose .
-    - swiftlint
-    - pod lib lint --verbose
-  # - stage: test
-  #   osx_image: xcode10
-  #   language: swift
-  #   env: TEST_DEVICE='platform=iOS Simulator,OS=12.0,name=iPhone SE'
-  #   script:
-  #   - >
-  #     xcodebuild test -enableCodeCoverage YES -scheme XMLCoder
-  #     -sdk iphonesimulator -destination "$TEST_DEVICE" | xcpretty
-  #   - >
-  #     xcodebuild test -enableCodeCoverage YES -scheme XMLCoder 
-  #     -sdk macosx | xcpretty
-  # - script:
-  #   - >
-  #     xcodebuild test -enableCodeCoverage YES -scheme XMLCoder
-  #     -sdk iphonesimulator -destination "$TEST_DEVICE" | xcpretty
-  #   - >
-  #     xcodebuild test -enableCodeCoverage YES -scheme XMLCoder 
-  #     -sdk macosx | xcpretty
-  #   osx_image: xcode10.1
-  #   language: swift
-  #   env: TEST_DEVICE='platform=iOS Simulator,OS=12.1,name=iPhone SE'
-  # - script:
-  #   - >
-  #     xcodebuild test -enableCodeCoverage YES -scheme XMLCoder
-  #     -sdk iphonesimulator -destination "$TEST_DEVICE" | xcpretty
-  #   - >
-  #     xcodebuild test -enableCodeCoverage YES -scheme XMLCoder 
-  #     -sdk macosx | xcpretty
-  #   osx_image: xcode10.2
-  #   language: swift
-  #   env: TEST_DEVICE='platform=iOS Simulator,OS=12.2,name=iPhone SE'
-  #   after_success:
-  #   - bash <(curl -s https://codecov.io/bash)
-  #   before_deploy:
-  #   - brew outdated carthage || brew upgrade carthage
-  #   - carthage build --no-skip-current
-  #   - carthage archive $FRAMEWORK_NAME
-  #   deploy:
-  #     provider: releases
-  #     api_key:
-  #       secure: yACVlrO+oqAPJ7NS2N2Cut8eCTO0yWWKuV9510tpwmsCKuHUJZ9fT1Z4zhteghGiDZJzZHzMteSK3YPHeCFBbZJAq95HeWV8ki0Cs+7tL8jO0U1zniilb/vk4MvT3z7QdzueXO+DHBw9nbszARwbfgBAWhkPbt9zKwk882Hoke5M9mfbQ9kUHNH+jTV5R7FdtkbkGpo1zzEglYZT0IshLTbBSlBjqEu9kJSJxTQjciKu6f/DvDYgV0AyXqi96hlmaSrTE9vM6bRxbN+t9QNAtlXxlB4mGiprKR8et1MFJHR9ECIpbzfsAWzehPtSksfXLgAfq0z0fIR3RRN4w76oMgAQcBS1xPnDFXjyMDv+QJHfXcGsACubU10FxZDHinF3odRzzAuQI2mxcvFJ7rcPVpe/Y1M1otxyRAlj3AE3yMp3eoTqoByjym/ckBSs9Ui5kgWIaQPtaGx6HkFFGjZlbxkNLcd6cQjrhAOUVF0FjABcdOi0ZM1HpBusdcdEx4aA68XcrZvWi9zWeG9rHb9Z20hJKme/zkuiAbKtwDFJ3y+WiQK27JtKTgz4VtDbtiWpjaj1Uw8FhbE/X+9fuN09HSfN5n/NDuIoDJtyAxBkalxGMggeWWHCb6vjYk9+jubyOYctGBh4jbRuSp2QMdR62GlghVa0ARSGiQOOWGEk6LU=
-  #     file: "$FRAMEWORK_NAME.framework.zip"
-  #     skip_cleanup: true
-  #     on:
-  #       repo: MaxDesiatov/XMLCoder
-  #       tags: true
+osx_image: xcode10.2
+language: swift
 
 env:
   global:
   - FRAMEWORK_NAME=XMLCoder
 
-# this runs the tests the second time, but it's the only way to make sure
-# that `Package.swift` is in a good state and `swift test` can only generate
-# coverage reports in Swift 5.0, see this issue for more details:
-# https://github.com/apple/swift-package-manager/pull/1787
-- swift test
+# matrix:
+#   include:
+#   - osx_image: xcode10
+#     language: swift
+#     env: TEST_DEVICE='platform=iOS Simulator,OS=12.0,name=iPhone SE'
+#   - osx_image: xcode10.1
+#     language: swift
+#     env: TEST_DEVICE='platform=iOS Simulator,OS=12.1,name=iPhone SE'
+#   - osx_image: xcode10.2
+#     language: swift
+#     env: TEST_DEVICE='platform=iOS Simulator,OS=12.2,name=iPhone SE'
+#     after_success:
+#     - bash <(curl -s https://codecov.io/bash)
+#     before_deploy:
+#     - brew outdated carthage || brew upgrade carthage
+#     - carthage build --no-skip-current
+#     - carthage archive $FRAMEWORK_NAME
+#     deploy:
+#       provider: releases
+#       api_key:
+#         secure: yACVlrO+oqAPJ7NS2N2Cut8eCTO0yWWKuV9510tpwmsCKuHUJZ9fT1Z4zhteghGiDZJzZHzMteSK3YPHeCFBbZJAq95HeWV8ki0Cs+7tL8jO0U1zniilb/vk4MvT3z7QdzueXO+DHBw9nbszARwbfgBAWhkPbt9zKwk882Hoke5M9mfbQ9kUHNH+jTV5R7FdtkbkGpo1zzEglYZT0IshLTbBSlBjqEu9kJSJxTQjciKu6f/DvDYgV0AyXqi96hlmaSrTE9vM6bRxbN+t9QNAtlXxlB4mGiprKR8et1MFJHR9ECIpbzfsAWzehPtSksfXLgAfq0z0fIR3RRN4w76oMgAQcBS1xPnDFXjyMDv+QJHfXcGsACubU10FxZDHinF3odRzzAuQI2mxcvFJ7rcPVpe/Y1M1otxyRAlj3AE3yMp3eoTqoByjym/ckBSs9Ui5kgWIaQPtaGx6HkFFGjZlbxkNLcd6cQjrhAOUVF0FjABcdOi0ZM1HpBusdcdEx4aA68XcrZvWi9zWeG9rHb9Z20hJKme/zkuiAbKtwDFJ3y+WiQK27JtKTgz4VtDbtiWpjaj1Uw8FhbE/X+9fuN09HSfN5n/NDuIoDJtyAxBkalxGMggeWWHCb6vjYk9+jubyOYctGBh4jbRuSp2QMdR62GlghVa0ARSGiQOOWGEk6LU=
+#       file: "$FRAMEWORK_NAME.framework.zip"
+#       skip_cleanup: true
+#       on:
+#         repo: MaxDesiatov/XMLCoder
+#         tags: true
+
+jobs:
+  include:
+  - stage: unit-test
+  script:
+  - >
+    xcodebuild test -enableCodeCoverage YES -scheme XMLCoder
+    -sdk iphonesimulator -destination "$TEST_DEVICE" | xcpretty
+  - >
+    xcodebuild test -enableCodeCoverage YES -scheme XMLCoder 
+    -sdk macosx | xcpretty
+  # this runs the tests the second time, but it's the only way to make sure
+  # that `Package.swift` is in a good state and `swift test` can only generate
+  # coverage reports in Swift 5.0, see this issue for more details:
+  # https://github.com/apple/swift-package-manager/pull/1787
+  - swift test
+
+before_install:
+- brew update
+- brew install swiftformat
+- brew outdated swiftlint || brew upgrade swiftlint
+script:
+- swiftformat --lint --verbose .
+- swiftlint
+- pod lib lint --verbose
 
 # this is commented because installing Jazzy on Travis doesn't work ¯\_(ツ)_/¯ 
 # - ./docs.sh

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,8 +15,8 @@ jobs:
       - swiftformat --lint --verbose .
       - swiftlint
       - pod lib lint --verbose
-  - &unit-test
-    stage: unit-test
+  - &test
+    stage: test
     osx_image: xcode10
     language: swift
     install: skip
@@ -33,10 +33,10 @@ jobs:
       # coverage reports in Swift 5.0, see this issue for more details:
       # https://github.com/apple/swift-package-manager/pull/1787
       - swift test
-  - <<: *unit-test
+  - <<: *test
     osx_image: xcode10.1
     env: TEST_DEVICE='platform=iOS Simulator,OS=12.1,name=iPhone SE'
-  - <<: *unit-test
+  - <<: *test
     osx_image: xcode10.2
     env: TEST_DEVICE='platform=iOS Simulator,OS=12.2,name=iPhone SE'
     after_success:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,36 +1,12 @@
-test: &test
-  script:
-  - >
-    xcodebuild test -enableCodeCoverage YES -scheme XMLCoder
-    -sdk iphonesimulator -destination "$TEST_DEVICE" | xcpretty
-  - >
-    xcodebuild test -enableCodeCoverage YES -scheme XMLCoder 
-    -sdk macosx | xcpretty
-
-jobs:
+matrix:
   include:
-  - stage: lint
-    before_install:
-    - brew update
-    - brew install swiftformat
-    - brew outdated swiftlint || brew upgrade swiftlint
-    script:
-    - swiftformat --lint --verbose .
-    - swiftlint
-    - pod lib lint --verbose
-    osx_image: xcode10.2
-    language: swift
-  - <<: *test
-    stage: test
-    osx_image: xcode10
+  - osx_image: xcode10
     language: swift
     env: TEST_DEVICE='platform=iOS Simulator,OS=12.0,name=iPhone SE'
-  - <<: *test
-    osx_image: xcode10.1
+  - osx_image: xcode10.1
     language: swift
     env: TEST_DEVICE='platform=iOS Simulator,OS=12.1,name=iPhone SE'
-  - <<: *test
-    osx_image: xcode10.2
+  - osx_image: xcode10.2
     language: swift
     env: TEST_DEVICE='platform=iOS Simulator,OS=12.2,name=iPhone SE'
     after_success:
@@ -49,9 +25,29 @@ jobs:
         repo: MaxDesiatov/XMLCoder
         tags: true
 
+jobs:
+  include:
+  - stage: lint
+    before_install:
+    - brew update
+    - brew install swiftformat
+    - brew outdated swiftlint || brew upgrade swiftlint
+    script:
+    - swiftformat --lint --verbose .
+    - swiftlint
+    - pod lib lint --verbose
+    osx_image: xcode10.2
+    language: swift
+
 env:
   global:
   - FRAMEWORK_NAME=XMLCoder
+
+script:
+- >
+  xcodebuild test -enableCodeCoverage YES -scheme XMLCoder
+  -sdk iphonesimulator -destination "$TEST_DEVICE" | xcpretty
+- xcodebuild test -enableCodeCoverage YES -scheme XMLCoder -sdk macosx | xcpretty
 
 # this runs the tests the second time, but it's the only way to make sure
 # that `Package.swift` is in a good state and `swift test` can only generate

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,12 +1,36 @@
-matrix:
+test: &test
+  script:
+  - >
+    xcodebuild test -enableCodeCoverage YES -scheme XMLCoder
+    -sdk iphonesimulator -destination "$TEST_DEVICE" | xcpretty
+  - >
+    xcodebuild test -enableCodeCoverage YES -scheme XMLCoder 
+    -sdk macosx | xcpretty
+
+jobs:
   include:
-  - osx_image: xcode10
+  - stage: lint
+    before_install:
+    - brew update
+    - brew install swiftformat
+    - brew outdated swiftlint || brew upgrade swiftlint
+    script:
+    - swiftformat --lint --verbose .
+    - swiftlint
+    - pod lib lint --verbose
+    osx_image: xcode10.2
+    language: swift
+  - <<: *test
+    stage: test
+    osx_image: xcode10
     language: swift
     env: TEST_DEVICE='platform=iOS Simulator,OS=12.0,name=iPhone SE'
-  - osx_image: xcode10.1
+  - <<: *test
+    osx_image: xcode10.1
     language: swift
     env: TEST_DEVICE='platform=iOS Simulator,OS=12.1,name=iPhone SE'
-  - osx_image: xcode10.2
+  - <<: *test
+    osx_image: xcode10.2
     language: swift
     env: TEST_DEVICE='platform=iOS Simulator,OS=12.2,name=iPhone SE'
     after_success:
@@ -25,29 +49,9 @@ matrix:
         repo: MaxDesiatov/XMLCoder
         tags: true
 
-jobs:
-  include:
-  - stage: lint
-    before_install:
-    - brew update
-    - brew install swiftformat
-    - brew outdated swiftlint || brew upgrade swiftlint
-    script:
-    - swiftformat --lint --verbose .
-    - swiftlint
-    - pod lib lint --verbose
-    osx_image: xcode10.2
-    language: swift
-
 env:
   global:
   - FRAMEWORK_NAME=XMLCoder
-
-script:
-- >
-  xcodebuild test -enableCodeCoverage YES -scheme XMLCoder
-  -sdk iphonesimulator -destination "$TEST_DEVICE" | xcpretty
-- xcodebuild test -enableCodeCoverage YES -scheme XMLCoder -sdk macosx | xcpretty
 
 # this runs the tests the second time, but it's the only way to make sure
 # that `Package.swift` is in a good state and `swift test` can only generate

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,16 @@
+jobs:
+  include:
+  - stage: lint
+    before_install:
+    - brew update
+    - brew install swiftformat
+    - brew outdated swiftlint || brew upgrade swiftlint
+    script:
+    - swiftformat --lint --verbose .
+    - swiftlint
+    - pod lib lint --verbose
+    osx_image: xcode10.2
+    language: swift
 
 matrix:
   include:
@@ -29,15 +42,8 @@ matrix:
 env:
   global:
   - FRAMEWORK_NAME=XMLCoder
-before_install:
-- gem install cocoapods --pre # Since Travis is not always on latest version
-- brew update
-- brew install swiftformat
-- brew outdated swiftlint || brew upgrade swiftlint
+
 script:
-- swiftformat --lint --verbose .
-- swiftlint
-- pod lib lint --verbose
 - >
   xcodebuild test -enableCodeCoverage YES -scheme XMLCoder
   -sdk iphonesimulator -destination "$TEST_DEVICE" | xcpretty
@@ -51,8 +57,3 @@ script:
 
 # this is commented because installing Jazzy on Travis doesn't work ¯\_(ツ)_/¯ 
 # - ./docs.sh
-
-# jobs:
-#   include:
-#   - stage: deploy
-#     osx_image: xcode10.1

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,6 @@
+osx_image: xcode10.2
+language: swift
+
 env:
   global:
   - FRAMEWORK_NAME=XMLCoder

--- a/.travis.yml
+++ b/.travis.yml
@@ -48,6 +48,7 @@ jobs:
     osx_image: xcode10
     language: swift
     install: skip
+    env: TEST_DEVICE='platform=iOS Simulator,OS=12.0,name=iPhone SE'
     script:
       - >
         xcodebuild test -enableCodeCoverage YES -scheme XMLCoder
@@ -60,6 +61,12 @@ jobs:
       # coverage reports in Swift 5.0, see this issue for more details:
       # https://github.com/apple/swift-package-manager/pull/1787
       - swift test
+  - <<: *unit-test
+    osx_image: xcode10.1
+    env: TEST_DEVICE='platform=iOS Simulator,OS=12.1,name=iPhone SE'
+  - <<: *unit-test
+    osx_image: xcode10.2
+    env: TEST_DEVICE='platform=iOS Simulator,OS=12.2,name=iPhone SE'
 
 # this is commented because installing Jazzy on Travis doesn't work ¯\_(ツ)_/¯ 
 # - ./docs.sh

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,21 +1,20 @@
-osx_image: xcode10.2
-language: swift
-
 env:
   global:
   - FRAMEWORK_NAME=XMLCoder
 
-before_install:
-  - brew update
-  - brew install swiftformat
-  - brew outdated swiftlint || brew upgrade swiftlint
-script:
-  - swiftformat --lint --verbose .
-  - swiftlint
-  - pod lib lint --verbose
-
 jobs:
   include:
+  - stage: lint
+    osx_image: xcode10.2
+    language: swift
+    before_install:
+      - brew update
+      - brew install swiftformat
+      - brew outdated swiftlint || brew upgrade swiftlint
+    script:
+      - swiftformat --lint --verbose .
+      - swiftlint
+      - pod lib lint --verbose
   - &unit-test
     stage: unit-test
     osx_image: xcode10

--- a/.travis.yml
+++ b/.travis.yml
@@ -47,6 +47,7 @@ jobs:
     stage: unit-test
     osx_image: xcode10
     language: swift
+    install: skip
     script:
       - >
         xcodebuild test -enableCodeCoverage YES -scheme XMLCoder

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,33 +5,6 @@ env:
   global:
   - FRAMEWORK_NAME=XMLCoder
 
-# matrix:
-#   include:
-#   - osx_image: xcode10
-#     language: swift
-#     env: TEST_DEVICE='platform=iOS Simulator,OS=12.0,name=iPhone SE'
-#   - osx_image: xcode10.1
-#     language: swift
-#     env: TEST_DEVICE='platform=iOS Simulator,OS=12.1,name=iPhone SE'
-#   - osx_image: xcode10.2
-#     language: swift
-#     env: TEST_DEVICE='platform=iOS Simulator,OS=12.2,name=iPhone SE'
-#     after_success:
-#     - bash <(curl -s https://codecov.io/bash)
-#     before_deploy:
-#     - brew outdated carthage || brew upgrade carthage
-#     - carthage build --no-skip-current
-#     - carthage archive $FRAMEWORK_NAME
-#     deploy:
-#       provider: releases
-#       api_key:
-#         secure: yACVlrO+oqAPJ7NS2N2Cut8eCTO0yWWKuV9510tpwmsCKuHUJZ9fT1Z4zhteghGiDZJzZHzMteSK3YPHeCFBbZJAq95HeWV8ki0Cs+7tL8jO0U1zniilb/vk4MvT3z7QdzueXO+DHBw9nbszARwbfgBAWhkPbt9zKwk882Hoke5M9mfbQ9kUHNH+jTV5R7FdtkbkGpo1zzEglYZT0IshLTbBSlBjqEu9kJSJxTQjciKu6f/DvDYgV0AyXqi96hlmaSrTE9vM6bRxbN+t9QNAtlXxlB4mGiprKR8et1MFJHR9ECIpbzfsAWzehPtSksfXLgAfq0z0fIR3RRN4w76oMgAQcBS1xPnDFXjyMDv+QJHfXcGsACubU10FxZDHinF3odRzzAuQI2mxcvFJ7rcPVpe/Y1M1otxyRAlj3AE3yMp3eoTqoByjym/ckBSs9Ui5kgWIaQPtaGx6HkFFGjZlbxkNLcd6cQjrhAOUVF0FjABcdOi0ZM1HpBusdcdEx4aA68XcrZvWi9zWeG9rHb9Z20hJKme/zkuiAbKtwDFJ3y+WiQK27JtKTgz4VtDbtiWpjaj1Uw8FhbE/X+9fuN09HSfN5n/NDuIoDJtyAxBkalxGMggeWWHCb6vjYk9+jubyOYctGBh4jbRuSp2QMdR62GlghVa0ARSGiQOOWGEk6LU=
-#       file: "$FRAMEWORK_NAME.framework.zip"
-#       skip_cleanup: true
-#       on:
-#         repo: MaxDesiatov/XMLCoder
-#         tags: true
-
 before_install:
   - brew update
   - brew install swiftformat
@@ -67,6 +40,21 @@ jobs:
   - <<: *unit-test
     osx_image: xcode10.2
     env: TEST_DEVICE='platform=iOS Simulator,OS=12.2,name=iPhone SE'
+    after_success:
+    - bash <(curl -s https://codecov.io/bash)
+    before_deploy:
+    - brew outdated carthage || brew upgrade carthage
+    - carthage build --no-skip-current
+    - carthage archive $FRAMEWORK_NAME
+    deploy:
+      provider: releases
+      api_key:
+        secure: yACVlrO+oqAPJ7NS2N2Cut8eCTO0yWWKuV9510tpwmsCKuHUJZ9fT1Z4zhteghGiDZJzZHzMteSK3YPHeCFBbZJAq95HeWV8ki0Cs+7tL8jO0U1zniilb/vk4MvT3z7QdzueXO+DHBw9nbszARwbfgBAWhkPbt9zKwk882Hoke5M9mfbQ9kUHNH+jTV5R7FdtkbkGpo1zzEglYZT0IshLTbBSlBjqEu9kJSJxTQjciKu6f/DvDYgV0AyXqi96hlmaSrTE9vM6bRxbN+t9QNAtlXxlB4mGiprKR8et1MFJHR9ECIpbzfsAWzehPtSksfXLgAfq0z0fIR3RRN4w76oMgAQcBS1xPnDFXjyMDv+QJHfXcGsACubU10FxZDHinF3odRzzAuQI2mxcvFJ7rcPVpe/Y1M1otxyRAlj3AE3yMp3eoTqoByjym/ckBSs9Ui5kgWIaQPtaGx6HkFFGjZlbxkNLcd6cQjrhAOUVF0FjABcdOi0ZM1HpBusdcdEx4aA68XcrZvWi9zWeG9rHb9Z20hJKme/zkuiAbKtwDFJ3y+WiQK27JtKTgz4VtDbtiWpjaj1Uw8FhbE/X+9fuN09HSfN5n/NDuIoDJtyAxBkalxGMggeWWHCb6vjYk9+jubyOYctGBh4jbRuSp2QMdR62GlghVa0ARSGiQOOWGEk6LU=
+      file: "$FRAMEWORK_NAME.framework.zip"
+      skip_cleanup: true
+      on:
+        repo: MaxDesiatov/XMLCoder
+        tags: true
 
 # this is commented because installing Jazzy on Travis doesn't work ¯\_(ツ)_/¯ 
 # - ./docs.sh

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,12 +1,45 @@
-matrix:
+jobs:
   include:
-  - osx_image: xcode10
+  - stage: lint
+    osx_image: xcode10.2
+    language: swift
+    before_install:
+    - brew update
+    - brew install swiftformat
+    - brew outdated swiftlint || brew upgrade swiftlint
+    script:
+    - swiftformat --lint --verbose .
+    - swiftlint
+    - pod lib lint --verbose
+  - stage: test
+    osx_image: xcode10
     language: swift
     env: TEST_DEVICE='platform=iOS Simulator,OS=12.0,name=iPhone SE'
-  - osx_image: xcode10.1
+    script:
+    - >
+      xcodebuild test -enableCodeCoverage YES -scheme XMLCoder
+      -sdk iphonesimulator -destination "$TEST_DEVICE" | xcpretty
+    - >
+      xcodebuild test -enableCodeCoverage YES -scheme XMLCoder 
+      -sdk macosx | xcpretty
+  - script:
+    - >
+      xcodebuild test -enableCodeCoverage YES -scheme XMLCoder
+      -sdk iphonesimulator -destination "$TEST_DEVICE" | xcpretty
+    - >
+      xcodebuild test -enableCodeCoverage YES -scheme XMLCoder 
+      -sdk macosx | xcpretty
+    osx_image: xcode10.1
     language: swift
     env: TEST_DEVICE='platform=iOS Simulator,OS=12.1,name=iPhone SE'
-  - osx_image: xcode10.2
+  - script:
+    - >
+      xcodebuild test -enableCodeCoverage YES -scheme XMLCoder
+      -sdk iphonesimulator -destination "$TEST_DEVICE" | xcpretty
+    - >
+      xcodebuild test -enableCodeCoverage YES -scheme XMLCoder 
+      -sdk macosx | xcpretty
+    osx_image: xcode10.2
     language: swift
     env: TEST_DEVICE='platform=iOS Simulator,OS=12.2,name=iPhone SE'
     after_success:
@@ -25,29 +58,9 @@ matrix:
         repo: MaxDesiatov/XMLCoder
         tags: true
 
-jobs:
-  include:
-  - stage: lint
-    before_install:
-    - brew update
-    - brew install swiftformat
-    - brew outdated swiftlint || brew upgrade swiftlint
-    script:
-    - swiftformat --lint --verbose .
-    - swiftlint
-    - pod lib lint --verbose
-    osx_image: xcode10.2
-    language: swift
-
 env:
   global:
   - FRAMEWORK_NAME=XMLCoder
-
-script:
-- >
-  xcodebuild test -enableCodeCoverage YES -scheme XMLCoder
-  -sdk iphonesimulator -destination "$TEST_DEVICE" | xcpretty
-- xcodebuild test -enableCodeCoverage YES -scheme XMLCoder -sdk macosx | xcpretty
 
 # this runs the tests the second time, but it's the only way to make sure
 # that `Package.swift` is in a good state and `swift test` can only generate

--- a/Package@swift-4.2.swift
+++ b/Package@swift-4.2.swift
@@ -1,4 +1,4 @@
-// swift-tools-version:5.0
+// swift-tools-version:4.2
 // The swift-tools-version declares the minimum version of Swift required to build this package.
 
 import PackageDescription

--- a/Sources/XMLCoder/Auxiliaries/XMLStackParser.swift
+++ b/Sources/XMLCoder/Auxiliaries/XMLStackParser.swift
@@ -72,8 +72,13 @@ class XMLStackParser: NSObject {
             upperBoundIndex = errorPosition + offset
         }
 
+        #if compiler(>=5.0)
+        let lowerBound = String.Index(utf16Offset: lowerBoundIndex, in: string)
+        let upperBound = String.Index(utf16Offset: upperBoundIndex, in: string)
+        #else
         let lowerBound = String.Index(encodedOffset: lowerBoundIndex)
         let upperBound = String.Index(encodedOffset: upperBoundIndex)
+        #endif
 
         let context = string[lowerBound..<upperBound]
 


### PR DESCRIPTION
The prevents linting stage from running multiple times in all parallel jobs. We're mostly going to develop with the latest version of Xcode, so we only care about linter and formatter warnings with that version. Thus, the linter stage runs first with the latest version, while actual tests run in parallel jobs of the next "test" stage.