### PR TITLE
Use map instead of mapValues/shuffle in XMLCoderElement.flatten

### DIFF
--- a/Sources/XMLCoder/Auxiliaries/XMLCoderElement.swift
+++ b/Sources/XMLCoder/Auxiliaries/XMLCoderElement.swift
@@ -45,9 +45,9 @@ struct XMLCoderElement: Equatable {
     }
 
     func flatten() -> KeyedBox {
-        let attributes = KeyedStorage(self.attributes.mapValues {
-            StringBox($0) as SimpleBox
-        }.shuffled())
+        let attributes = KeyedStorage(self.attributes.map { (key, value) in
+            (key: key, value: StringBox(value) as SimpleBox)
+        })
         let storage = KeyedStorage<String, Box>()
 
         var elements = self.elements.reduce(storage) { $0.merge(element: $1) }

--- a/Sources/XMLCoder/Auxiliaries/XMLCoderElement.swift
+++ b/Sources/XMLCoder/Auxiliaries/XMLCoderElement.swift
@@ -49,7 +49,6 @@ struct XMLCoderElement: Equatable {
             (key: key, value: StringBox(value) as SimpleBox)
         })
         let storage = KeyedStorage<String, Box>()
-
         var elements = self.elements.reduce(storage) { $0.merge(element: $1) }
 
         // Handle attributed unkeyed value <foo attr="bar">zap</foo>


### PR DESCRIPTION
This PR uses a `map` over `key`-`value` pairs instead of `mapValues` along with `shuffled()`  when transforming attributes into a `Box`-ed representation within `XMLCoderElement.flatten()`.

At first, I was wondering what the `shuffled()` was for. I tried to get rid of it on its own, but the compiler didn't appreciate that very much when it came to `KeyedStorage.init<S>(_ sequence: S) where S: Sequence, S.Element == (Key, Value)`. Could this be a moment of ambiguity between `(Key,Value)` and `(key: Key, value: Value)`?

Ultimately, `mapValues` alone should do the trick, but I thought it might be nice to avoid another O(*n*) pass if not necessary.

Did `shuffled` have any other purpose than juggling types with the compiler?
