### PR TITLE
Replace UnkeyedBox with Array, refine KeyedStorage

### DIFF
--- a/Sources/XMLCoder/Auxiliaries/Box/KeyedBox.swift
+++ b/Sources/XMLCoder/Auxiliaries/Box/KeyedBox.swift
@@ -22,6 +22,10 @@ struct KeyedBox {
             attributes: attributes
         )
     }
+
+    var value: SimpleBox? {
+        return elements["value"].first as? SimpleBox
+    }
 }
 
 extension KeyedBox {
@@ -41,17 +45,6 @@ extension KeyedBox: Box {
 
     func xmlString() -> String? {
         return nil
-    }
-}
-
-extension KeyedBox {
-    var value: SimpleBox? {
-        guard
-            elements.count == 1,
-            let value = elements["value"] as? SimpleBox
-            ?? elements[""] as? SimpleBox,
-            !value.isNull else { return nil }
-        return value
     }
 }
 

--- a/Sources/XMLCoder/Auxiliaries/Box/SharedBox.swift
+++ b/Sources/XMLCoder/Auxiliaries/Box/SharedBox.swift
@@ -12,7 +12,7 @@ class SharedBox<Unboxed: Box> {
         unboxed = wrapped
     }
 
-    func withShared<Result>(_ body: (inout Unboxed) throws -> Result) rethrows -> Result {
+    func withShared<T>(_ body: (inout Unboxed) throws -> T) rethrows -> T {
         return try body(&unboxed)
     }
 }

--- a/Sources/XMLCoder/Auxiliaries/Box/UnkeyedBox.swift
+++ b/Sources/XMLCoder/Auxiliaries/Box/UnkeyedBox.swift
@@ -5,59 +5,14 @@
 //  Created by Vincent Esche on 11/20/18.
 //
 
-// Minimalist implementation of an order-preserving unkeyed box:
-struct UnkeyedBox {
-    typealias Element = Box
-    typealias Unboxed = [Element]
+typealias UnkeyedBox = [Box]
 
-    private(set) var unboxed: Unboxed
-
-    var count: Int {
-        return unboxed.count
-    }
-
-    subscript(index: Int) -> Element {
-        get {
-            return unboxed[index]
-        }
-        set {
-            unboxed[index] = newValue
-        }
-    }
-
-    init(_ unboxed: Unboxed = []) {
-        self.unboxed = unboxed
-    }
-
-    mutating func append(_ newElement: Element) {
-        unboxed.append(newElement)
-    }
-
-    mutating func insert(_ newElement: Element, at index: Int) {
-        unboxed.insert(newElement, at: index)
-    }
-}
-
-extension UnkeyedBox: Box {
+extension Array: Box {
     var isNull: Bool {
         return false
     }
 
     func xmlString() -> String? {
         return nil
-    }
-}
-
-extension UnkeyedBox: Sequence {
-    typealias Iterator = Unboxed.Iterator
-
-    func makeIterator() -> Iterator {
-        return unboxed.makeIterator()
-    }
-}
-
-extension UnkeyedBox: CustomStringConvertible {
-    var description: String {
-        return "\(unboxed)"
     }
 }

--- a/Sources/XMLCoder/Auxiliaries/KeyedStorage.swift
+++ b/Sources/XMLCoder/Auxiliaries/KeyedStorage.swift
@@ -6,23 +6,10 @@
 //
 
 struct KeyedStorage<Key: Hashable & Comparable, Value> {
-    struct Iterator: IteratorProtocol {
-        fileprivate var orderIterator: Order.Iterator
-        fileprivate var buffer: Buffer
-        mutating func next() -> (Key, Value)? {
-            guard
-                let key = orderIterator.next(),
-                let value = buffer[key]
-            else { return nil }
+    typealias Buffer = [(Key, Value)]
+    typealias KeyMap = [Key: [Int]]
 
-            return (key, value)
-        }
-    }
-
-    typealias Buffer = [Key: Value]
-    typealias Order = [Key]
-
-    fileprivate var order = Order()
+    fileprivate var keyMap = KeyMap()
     fileprivate var buffer = Buffer()
 
     var isEmpty: Bool {
@@ -34,23 +21,26 @@ struct KeyedStorage<Key: Hashable & Comparable, Value> {
     }
 
     var keys: [Key] {
-        return order
+        return buffer.map { $0.0 }
     }
 
     init<S>(_ sequence: S) where S: Sequence, S.Element == (Key, Value) {
-        order = sequence.map { $0.0 }
-        buffer = Dictionary(uniqueKeysWithValues: sequence)
+        buffer = Buffer()
+        keyMap = KeyMap()
+        sequence.forEach { key, value in append(value, at: key) }
     }
 
-    subscript(key: Key) -> Value? {
-        get {
-            return buffer[key]
-        }
-        set {
-            if buffer[key] == nil {
-                order.append(key)
-            }
-            buffer[key] = newValue
+    subscript(key: Key) -> [Value] {
+        return keyMap[key]?.map { buffer[$0].1 } ?? []
+    }
+
+    mutating func append(_ value: Value, at key: Key) {
+        let i = buffer.count
+        buffer.append((key, value))
+        if keyMap[key] != nil {
+            keyMap[key]?.append(i)
+        } else {
+            keyMap[key] = [i]
         }
     }
 
@@ -68,64 +58,18 @@ struct KeyedStorage<Key: Hashable & Comparable, Value> {
 }
 
 extension KeyedStorage: Sequence {
-    func makeIterator() -> Iterator {
-        return Iterator(orderIterator: order.makeIterator(), buffer: buffer)
+    func makeIterator() -> Buffer.Iterator {
+        return buffer.makeIterator()
     }
 }
 
 extension KeyedStorage: CustomStringConvertible {
     var description: String {
-        let result = order.compactMap { (key: Key) -> String? in
-            guard let value = buffer[key] else { return nil }
-
-            return "\"\(key)\": \(value)"
+        let result = buffer.map { key, value in
+            "\"\(key)\": \(value)"
         }.joined(separator: ", ")
 
         return "[\(result)]"
-    }
-}
-
-private extension KeyedStorage where Key == String, Value == Box {
-    mutating func merge(value: String, at key: String) {
-        switch self[key] {
-        case var unkeyedBox as UnkeyedBox:
-            unkeyedBox.append(StringBox(value))
-            self[key] = unkeyedBox
-        case let stringBox as StringBox:
-            self[key] = UnkeyedBox([stringBox, StringBox(value)])
-        default:
-            self[key] = StringBox(value)
-        }
-    }
-
-    mutating func mergeElementsAttributes(from element: XMLCoderElement) {
-        let hasValue = element.value != nil
-
-        let key = element.key
-        let content = element.transformToBoxTree()
-        switch self[key] {
-        case var unkeyedBox as UnkeyedBox:
-            unkeyedBox.append(content)
-            self[key] = unkeyedBox
-        case let keyedBox as KeyedBox:
-            self[key] = UnkeyedBox([keyedBox, content])
-        case let box? where !hasValue:
-            self[key] = UnkeyedBox([box, content])
-        default:
-            self[key] = content
-        }
-    }
-
-    mutating func mergeNull(at key: String) {
-        switch self[key] {
-        case var unkeyedBox as UnkeyedBox:
-            unkeyedBox.append(NullBox())
-            self[key] = unkeyedBox
-        case let box?:
-            self[key] = UnkeyedBox([box, NullBox()])
-        default:
-            self[key] = NullBox()
-        }
     }
 }
 
@@ -137,11 +81,11 @@ extension KeyedStorage where Key == String, Value == Box {
         let hasAttributes = !element.attributes.isEmpty
 
         if hasElements || hasAttributes {
-            result.mergeElementsAttributes(from: element)
+            result.append(element.transformToBoxTree(), at: element.key)
         } else if let value = element.value {
-            result.merge(value: value, at: element.key)
+            result.append(StringBox(value), at: element.key)
         } else {
-            result.mergeNull(at: element.key)
+            result.append(NullBox(), at: element.key)
         }
 
         return result

--- a/Sources/XMLCoder/Auxiliaries/KeyedStorage.swift
+++ b/Sources/XMLCoder/Auxiliaries/KeyedStorage.swift
@@ -65,9 +65,7 @@ extension KeyedStorage: Sequence {
 
 extension KeyedStorage: CustomStringConvertible {
     var description: String {
-        let result = buffer.map { key, value in
-            "\"\(key)\": \(value)"
-        }.joined(separator: ", ")
+        let result = buffer.map { "\"\($0)\": \($1)" }.joined(separator: ", ")
 
         return "[\(result)]"
     }

--- a/Sources/XMLCoder/Auxiliaries/Metatypes.swift
+++ b/Sources/XMLCoder/Auxiliaries/Metatypes.swift
@@ -7,7 +7,7 @@
 
 /// Type-erased protocol helper for a metatype check in generic `decode`
 /// overload.
-protocol AnyEmptySequence {
+protocol AnySequence {
     init()
 }
 
@@ -15,13 +15,13 @@ protocol AnyArray {
     static var elementType: Any.Type { get }
 }
 
-extension Array: AnyEmptySequence, AnyArray {
+extension Array: AnySequence, AnyArray {
     static var elementType: Any.Type {
         return Element.self
     }
 }
 
-extension Dictionary: AnyEmptySequence {}
+extension Dictionary: AnySequence {}
 
 /// Type-erased protocol helper for a metatype check in generic `decode`
 /// overload.

--- a/Sources/XMLCoder/Auxiliaries/Metatypes.swift
+++ b/Sources/XMLCoder/Auxiliaries/Metatypes.swift
@@ -11,11 +11,7 @@ protocol AnySequence {
     init()
 }
 
-protocol AnyArray {
-    static var elementType: Any.Type { get }
-}
-
-extension Array: AnySequence, AnyArray {
+extension Array: AnySequence {
     static var elementType: Any.Type {
         return Element.self
     }

--- a/Sources/XMLCoder/Auxiliaries/Metatypes.swift
+++ b/Sources/XMLCoder/Auxiliaries/Metatypes.swift
@@ -11,11 +11,7 @@ protocol AnySequence {
     init()
 }
 
-extension Array: AnySequence {
-    static var elementType: Any.Type {
-        return Element.self
-    }
-}
+extension Array: AnySequence {}
 
 extension Dictionary: AnySequence {}
 

--- a/Sources/XMLCoder/Auxiliaries/XMLCoderElement.swift
+++ b/Sources/XMLCoder/Auxiliaries/XMLCoderElement.swift
@@ -56,7 +56,7 @@ struct XMLCoderElement: Equatable {
         // Handle attributed unkeyed value <foo attr="bar">zap</foo>
         // Value should be zap. Detect only when no other elements exist
         if elements.isEmpty, let value = value {
-            elements["value"] = StringBox(value)
+            elements.append(StringBox(value), at: "value")
         }
         let keyedBox = KeyedBox(elements: elements, attributes: attributes)
 

--- a/Sources/XMLCoder/Decoder/DecodingErrorExtension.swift
+++ b/Sources/XMLCoder/Decoder/DecodingErrorExtension.swift
@@ -19,7 +19,7 @@ extension DecodingError {
     /// - parameter expectation: The type expected to be encountered.
     /// - parameter reality: The value that was encountered instead of the expected type.
     /// - returns: A `DecodingError` with the appropriate path and debug description.
-    static func _typeMismatch(at path: [CodingKey], expectation: Any.Type, reality: Box) -> DecodingError {
+    static func typeMismatch(at path: [CodingKey], expectation: Any.Type, reality: Box) -> DecodingError {
         let description = "Expected to decode \(expectation) but found \(_typeDescription(of: reality)) instead."
         return .typeMismatch(expectation, Context(codingPath: path, debugDescription: description))
     }

--- a/Sources/XMLCoder/Decoder/XMLDecoderImplementation.swift
+++ b/Sources/XMLCoder/Decoder/XMLDecoderImplementation.swift
@@ -134,7 +134,6 @@ class XMLDecoderImplementation: Decoder {
             )
         }
 
-        let unkeyed: SharedBox<UnkeyedBox>
         switch topContainer {
         case let unkeyed as SharedBox<UnkeyedBox>:
             return XMLUnkeyedDecodingContainer(referencing: self, wrapping: unkeyed)

--- a/Sources/XMLCoder/Decoder/XMLDecoderImplementation.swift
+++ b/Sources/XMLCoder/Decoder/XMLDecoderImplementation.swift
@@ -174,14 +174,14 @@ extension XMLDecoderImplementation {
             return value
         case let keyedBox as SharedBox<KeyedBox>:
             guard
-                let value = keyedBox.withShared({ $0.elements["value"].first as? B })
+                let value = keyedBox.withShared({ $0.value as? B })
             else { throw error }
             return value
         case is NullBox:
             throw error
         case let keyedBox as KeyedBox:
             guard
-                let value = keyedBox.elements["value"].first as? B
+                let value = keyedBox.value as? B
             else { fallthrough }
             return value
         default:

--- a/Sources/XMLCoder/Decoder/XMLKeyedDecodingContainer.swift
+++ b/Sources/XMLCoder/Decoder/XMLKeyedDecodingContainer.swift
@@ -338,15 +338,9 @@ extension XMLKeyedDecodingContainer {
             value = try decoder.unbox(box)
         }
 
-        if value == nil {
-            if let type = type as? AnyArray.Type,
-                type.elementType is AnyOptional.Type,
-                let result = [nil] as? T {
-                return result
-            } else if let type = type as? AnyOptional.Type,
-                let result = type.init() as? T {
-                return result
-            }
+        if value == nil, let type = type as? AnyOptional.Type,
+            let result = type.init() as? T {
+            return result
         }
 
         guard let unwrapped = value else {

--- a/Sources/XMLCoder/Decoder/XMLKeyedDecodingContainer.swift
+++ b/Sources/XMLCoder/Decoder/XMLKeyedDecodingContainer.swift
@@ -316,7 +316,7 @@ extension XMLKeyedDecodingContainer {
             box = elements
         case .elementOrAttribute:
             guard
-                let anyBox = elements.isEmpty ? attributes.first : elements as Box
+                let anyBox = elements.isEmpty ? attributes.first : elements as Box?
             else {
                 throw DecodingError.keyNotFound(key, DecodingError.Context(
                     codingPath: decoder.codingPath,

--- a/Sources/XMLCoder/Decoder/XMLKeyedDecodingContainer.swift
+++ b/Sources/XMLCoder/Decoder/XMLKeyedDecodingContainer.swift
@@ -331,8 +331,8 @@ extension XMLKeyedDecodingContainer {
         }
 
         let value: T?
-        if !(type is AnySequence.Type), let keyedBox = box as? UnkeyedBox,
-            let first = keyedBox.first {
+        if !(type is AnySequence.Type), let unkeyedBox = box as? UnkeyedBox,
+            let first = unkeyedBox.first {
             value = try decoder.unbox(first)
         } else {
             value = try decoder.unbox(box)

--- a/Sources/XMLCoder/Decoder/XMLUnkeyedDecodingContainer.swift
+++ b/Sources/XMLCoder/Decoder/XMLUnkeyedDecodingContainer.swift
@@ -150,9 +150,9 @@ struct XMLUnkeyedDecodingContainer: UnkeyedDecodingContainer {
         }
 
         guard let keyedContainer = value as? KeyedContainer else {
-            throw DecodingError._typeMismatch(at: codingPath,
-                                              expectation: [String: Any].self,
-                                              reality: value)
+            throw DecodingError.typeMismatch(at: codingPath,
+                                             expectation: [String: Any].self,
+                                             reality: value)
         }
 
         currentIndex += 1
@@ -187,9 +187,9 @@ struct XMLUnkeyedDecodingContainer: UnkeyedDecodingContainer {
         }
 
         guard let unkeyedContainer = value as? UnkeyedContainer else {
-            throw DecodingError._typeMismatch(at: codingPath,
-                                              expectation: UnkeyedBox.self,
-                                              reality: value)
+            throw DecodingError.typeMismatch(at: codingPath,
+                                             expectation: UnkeyedBox.self,
+                                             reality: value)
         }
 
         currentIndex += 1

--- a/Sources/XMLCoder/Decoder/XMLUnkeyedDecodingContainer.swift
+++ b/Sources/XMLCoder/Decoder/XMLUnkeyedDecodingContainer.swift
@@ -9,16 +9,13 @@
 import Foundation
 
 struct XMLUnkeyedDecodingContainer: UnkeyedDecodingContainer {
-    typealias KeyedContainer = SharedBox<KeyedBox>
-    typealias UnkeyedContainer = SharedBox<UnkeyedBox>
-
     // MARK: Properties
 
     /// A reference to the decoder we're reading from.
     private let decoder: XMLDecoderImplementation
 
     /// A reference to the container we're reading from.
-    private let container: UnkeyedContainer
+    private let container: SharedBox<UnkeyedBox>
 
     /// The path of coding keys taken to get to this point in decoding.
     public private(set) var codingPath: [CodingKey]
@@ -29,7 +26,7 @@ struct XMLUnkeyedDecodingContainer: UnkeyedDecodingContainer {
     // MARK: - Initialization
 
     /// Initializes `self` by referencing the given decoder and container.
-    init(referencing decoder: XMLDecoderImplementation, wrapping container: UnkeyedContainer) {
+    init(referencing decoder: XMLDecoderImplementation, wrapping container: SharedBox<UnkeyedBox>) {
         self.decoder = decoder
         self.container = container
         codingPath = decoder.codingPath
@@ -149,7 +146,7 @@ struct XMLUnkeyedDecodingContainer: UnkeyedDecodingContainer {
             ))
         }
 
-        guard let keyedContainer = value as? KeyedContainer else {
+        guard let keyedContainer = value as? SharedBox<KeyedBox> else {
             throw DecodingError.typeMismatch(at: codingPath,
                                              expectation: [String: Any].self,
                                              reality: value)
@@ -186,7 +183,7 @@ struct XMLUnkeyedDecodingContainer: UnkeyedDecodingContainer {
             ))
         }
 
-        guard let unkeyedContainer = value as? UnkeyedContainer else {
+        guard let unkeyedContainer = value as? SharedBox<UnkeyedBox> else {
             throw DecodingError.typeMismatch(at: codingPath,
                                              expectation: UnkeyedBox.self,
                                              reality: value)

--- a/Sources/XMLCoder/Decoder/XMLUnkeyedDecodingContainer.swift
+++ b/Sources/XMLCoder/Decoder/XMLUnkeyedDecodingContainer.swift
@@ -101,21 +101,8 @@ struct XMLUnkeyedDecodingContainer: UnkeyedDecodingContainer {
         decoder.codingPath.append(XMLKey(index: currentIndex))
         defer { self.decoder.codingPath.removeLast() }
 
-        let box: Box
-
-        // work around unkeyed box wrapped as single element of keyed box
-        if let type = type as? AnyArray.Type,
-            let keyedBox = container
-            .withShared({ $0[self.currentIndex] as? KeyedBox }),
-            keyedBox.attributes.isEmpty,
-            keyedBox.elements.count == 1,
-            let firstKey = keyedBox.elements.keys.first,
-            let unkeyedBox = keyedBox.elements[firstKey] {
-            box = unkeyedBox
-        } else {
-            box = container.withShared { unkeyedBox in
-                unkeyedBox[self.currentIndex]
-            }
+        let box = container.withShared { unkeyedBox in
+            unkeyedBox[self.currentIndex]
         }
 
         let value = try decode(decoder, box)

--- a/Sources/XMLCoder/Encoder/XMLKeyedEncodingContainer.swift
+++ b/Sources/XMLCoder/Encoder/XMLKeyedEncodingContainer.swift
@@ -64,8 +64,8 @@ struct XMLKeyedEncodingContainer<K: CodingKey>: KeyedEncodingContainerProtocol {
     // MARK: - KeyedEncodingContainerProtocol Methods
 
     public mutating func encodeNil(forKey key: Key) throws {
-        container.withShared { container in
-            container.elements[_converted(key).stringValue] = NullBox()
+        container.withShared {
+            $0.elements.append(NullBox(), at: _converted(key).stringValue)
         }
     }
 
@@ -109,13 +109,13 @@ struct XMLKeyedEncodingContainer<K: CodingKey>: KeyedEncodingContainerProtocol {
                 ))
             }
             mySelf.container.withShared { container in
-                container.attributes[mySelf._converted(key).stringValue] = attribute
+                container.attributes.append(attribute, at: mySelf._converted(key).stringValue)
             }
         }
 
         let elementEncoder: (T, Key, Box) throws -> () = { _, key, box in
             mySelf.container.withShared { container in
-                container.elements[mySelf._converted(key).stringValue] = box
+                container.elements.append(box, at: mySelf._converted(key).stringValue)
             }
         }
 
@@ -141,7 +141,7 @@ struct XMLKeyedEncodingContainer<K: CodingKey>: KeyedEncodingContainerProtocol {
         let sharedKeyed = SharedBox(KeyedBox())
 
         self.container.withShared { container in
-            container.elements[_converted(key).stringValue] = sharedKeyed
+            container.elements.append(sharedKeyed, at: _converted(key).stringValue)
         }
 
         codingPath.append(key)
@@ -161,7 +161,7 @@ struct XMLKeyedEncodingContainer<K: CodingKey>: KeyedEncodingContainerProtocol {
         let sharedUnkeyed = SharedBox(UnkeyedBox())
 
         container.withShared { container in
-            container.elements[_converted(key).stringValue] = sharedUnkeyed
+            container.elements.append(sharedUnkeyed, at: _converted(key).stringValue)
         }
 
         codingPath.append(key)

--- a/Sources/XMLCoder/Encoder/XMLReferencingEncoder.swift
+++ b/Sources/XMLCoder/Encoder/XMLReferencingEncoder.swift
@@ -98,7 +98,7 @@ class XMLReferencingEncoder: XMLEncoderImplementation {
             }
         case let .keyed(sharedKeyedBox, key):
             sharedKeyedBox.withShared { keyedBox in
-                keyedBox.elements[key] = box
+                keyedBox.elements.append(box, at: key)
             }
         }
     }

--- a/Tests/XMLCoderTests/Box/KeyedBoxTests.swift
+++ b/Tests/XMLCoderTests/Box/KeyedBoxTests.swift
@@ -25,11 +25,11 @@ class KeyedBoxTests: XCTestCase {
         let (elements, attributes) = box.unboxed
 
         XCTAssertEqual(elements.count, 2)
-        XCTAssertEqual(elements["foo"] as? StringBox, StringBox("bar"))
-        XCTAssertEqual(elements["baz"] as? IntBox, IntBox(42))
+        XCTAssertEqual(elements["foo"].first as? StringBox, StringBox("bar"))
+        XCTAssertEqual(elements["baz"].first as? IntBox, IntBox(42))
 
         XCTAssertEqual(attributes.count, 1)
-        XCTAssertEqual(attributes["baz"] as? StringBox, StringBox("blee"))
+        XCTAssertEqual(attributes["baz"].first as? StringBox, StringBox("blee"))
     }
 
     func testXMLString() {
@@ -57,8 +57,8 @@ class KeyedBoxTests: XCTestCase {
             elements: elements,
             attributes: [("baz", StringBox("blee"))]
         )
-        box.elements["bar"] = NullBox()
+        box.elements.append(NullBox(), at: "bar")
         XCTAssertEqual(box.elements.count, 3)
-        XCTAssertEqual(box.elements["bar"] as? NullBox, NullBox())
+        XCTAssertEqual(box.elements["bar"].first as? NullBox, NullBox())
     }
 }

--- a/Tests/XMLCoderTests/Box/UnkeyedBoxTests.swift
+++ b/Tests/XMLCoderTests/Box/UnkeyedBoxTests.swift
@@ -9,20 +9,17 @@ import XCTest
 @testable import XMLCoder
 
 class UnkeyedBoxTests: XCTestCase {
-    typealias Boxed = UnkeyedBox
-
-    let box = Boxed([StringBox("foo"), IntBox(42)])
+    let box: UnkeyedBox = [StringBox("foo"), IntBox(42)]
 
     func testIsNull() {
-        let box = Boxed()
+        let box = UnkeyedBox()
         XCTAssertEqual(box.isNull, false)
     }
 
     func testUnbox() {
-        let unboxed = box.unboxed
-        XCTAssertEqual(unboxed.count, 2)
-        XCTAssertEqual(unboxed[0] as? StringBox, StringBox("foo"))
-        XCTAssertEqual(unboxed[1] as? IntBox, IntBox(42))
+        XCTAssertEqual(box.count, 2)
+        XCTAssertEqual(box[0] as? StringBox, StringBox("foo"))
+        XCTAssertEqual(box[1] as? IntBox, IntBox(42))
     }
 
     func testXMLString() {
@@ -41,7 +38,7 @@ class UnkeyedBoxTests: XCTestCase {
     }
 
     func testSubscript() {
-        var box = Boxed([StringBox("foo"), IntBox(42)])
+        var box = self.box
         box[0] = NullBox()
         XCTAssertEqual(box.count, 2)
         XCTAssertEqual(box[0] as? NullBox, NullBox())
@@ -49,7 +46,7 @@ class UnkeyedBoxTests: XCTestCase {
     }
 
     func testInsertAt() {
-        var box = Boxed([StringBox("foo"), IntBox(42)])
+        var box = self.box
         box.insert(NullBox(), at: 1)
         XCTAssertEqual(box.count, 3)
 

--- a/Tests/XMLCoderTests/MixedContainerTest.swift
+++ b/Tests/XMLCoderTests/MixedContainerTest.swift
@@ -1,0 +1,57 @@
+//
+//  MixedContainerTest.swift
+//  XMLCoderTests
+//
+//  Created by Max Desiatov on 21/05/2019.
+//
+
+import XCTest
+@testable import XMLCoder
+
+private struct Container<T: Codable>: Codable {
+    let unkeyed: [T]
+    let keyed: [String: T]
+}
+
+private let xml = """
+<container>
+    <unkeyed>
+        <unkeyed>1</unkeyed>
+        <unkeyed>2</unkeyed>
+        <unkeyed>3</unkeyed>
+        <unkeyed>4</unkeyed>
+        <unkeyed>5</unkeyed>
+    </unkeyed>
+    <unkeyed>
+        <unkeyed>1</unkeyed>
+        <unkeyed>2</unkeyed>
+        <unkeyed>3</unkeyed>
+        <unkeyed>4</unkeyed>
+        <unkeyed>5</unkeyed>
+    </unkeyed>
+    <keyed>
+        <key_213>1</key_213>
+        <key_213>2</key_213>
+        <key_213>3</key_213>
+        <key_213>4</key_213>
+        <key_213>5</key_213>
+        <key_364>1</key_364>
+        <key_364>2</key_364>
+        <key_364>3</key_364>
+        <key_364>4</key_364>
+        <key_364>5</key_364>
+        <key_489>1</key_489>
+        <key_489>2</key_489>
+        <key_489>3</key_489>
+        <key_489>4</key_489>
+        <key_489>5</key_489>
+    </keyed>
+</container>
+""".data(using: .utf8)!
+
+final class MixedContainerTest: XCTestCase {
+    func test() throws {
+        let result = try XMLDecoder().decode(Container<[Int]>.self, from: xml)
+        XCTAssertEqual(result.unkeyed.count, 2)
+    }
+}

--- a/XMLCoder.xcodeproj/project.pbxproj
+++ b/XMLCoder.xcodeproj/project.pbxproj
@@ -91,6 +91,7 @@
 		D1761D1F2247F04500F53CEF /* DynamicNodeDecodingTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = D1761D1E2247F04500F53CEF /* DynamicNodeDecodingTest.swift */; };
 		D1A3D4AD227AD9BF00F28969 /* KeyDecodingStrategyTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = D1A3D4AB227AD9BC00F28969 /* KeyDecodingStrategyTest.swift */; };
 		D1AC9466224E3E63004AB49B /* AttributedEnumIntrinsicTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = D1AC9464224E3E1F004AB49B /* AttributedEnumIntrinsicTest.swift */; };
+		D1CAD3622293FAB80077901D /* MixedContainerTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = D1CAD3612293FAB80077901D /* MixedContainerTest.swift */; };
 		D1CB1EF521EA9599009CAF02 /* RJITest.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_37 /* RJITest.swift */; };
 		D1CFC8242226B13F00B03222 /* NamespaceTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = D1CFC8222226AFB400B03222 /* NamespaceTest.swift */; };
 		D1E0C85321D8E65E0042A261 /* ErrorContextTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = D1E0C85121D8E6540042A261 /* ErrorContextTest.swift */; };
@@ -213,6 +214,7 @@
 		D1761D1E2247F04500F53CEF /* DynamicNodeDecodingTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DynamicNodeDecodingTest.swift; sourceTree = "<group>"; };
 		D1A3D4AB227AD9BC00F28969 /* KeyDecodingStrategyTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KeyDecodingStrategyTest.swift; sourceTree = "<group>"; };
 		D1AC9464224E3E1F004AB49B /* AttributedEnumIntrinsicTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AttributedEnumIntrinsicTest.swift; sourceTree = "<group>"; };
+		D1CAD3612293FAB80077901D /* MixedContainerTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MixedContainerTest.swift; sourceTree = "<group>"; };
 		D1CFC8222226AFB400B03222 /* NamespaceTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NamespaceTest.swift; sourceTree = "<group>"; };
 		D1E0C85121D8E6540042A261 /* ErrorContextTest.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ErrorContextTest.swift; sourceTree = "<group>"; };
 		D1E0C85421D91EBF0042A261 /* Metatypes.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Metatypes.swift; sourceTree = "<group>"; };
@@ -411,6 +413,7 @@
 				D14D8A8521F1D6B300B0D31A /* SingleChildTests.swift */,
 				D11815BF227788BA008836E4 /* SpacePreserveTest.swift */,
 				D1A3D4AB227AD9BC00F28969 /* KeyDecodingStrategyTest.swift */,
+				D1CAD3612293FAB80077901D /* MixedContainerTest.swift */,
 			);
 			name = XMLCoderTests;
 			path = Tests/XMLCoderTests;
@@ -696,6 +699,7 @@
 				D1E0C85321D8E65E0042A261 /* ErrorContextTest.swift in Sources */,
 				D1CB1EF521EA9599009CAF02 /* RJITest.swift in Sources */,
 				BF9457F421CBB6BC005ACFDE /* UIntTests.swift in Sources */,
+				D1CAD3622293FAB80077901D /* MixedContainerTest.swift in Sources */,
 				BF9457F121CBB6BC005ACFDE /* FloatTests.swift in Sources */,
 				BF8171D021D3B1BD00901EB0 /* DecodingContainerTests.swift in Sources */,
 				BF9457EF21CBB6BC005ACFDE /* NullTests.swift in Sources */,

--- a/XMLCoder.xcodeproj/xcshareddata/xcbaselines/XMLCoder::XMLCoderTests.xcbaseline/76E090BF-7AFE-4988-A06A-3C423396A4A4.plist
+++ b/XMLCoder.xcodeproj/xcshareddata/xcbaselines/XMLCoder::XMLCoderTests.xcbaseline/76E090BF-7AFE-4988-A06A-3C423396A4A4.plist
@@ -11,7 +11,7 @@
 				<key>com.apple.XCTPerformanceMetric_WallClockTime</key>
 				<dict>
 					<key>baselineAverage</key>
-					<real>0.076639</real>
+					<real>0.355</real>
 					<key>baselineIntegrationDisplayName</key>
 					<string>Local Baseline</string>
 				</dict>


### PR DESCRIPTION
`UnkeyedBox` is a wrapper for `[Box]`, the assumption is that adding direct `Box` conformance to `[Box]` would simplify things a bit. Also, `KeyedStorage` now always stores `[Box]` per key without any special handling for single items per key to simplify this even more. In addition, order of values is preserved for all keys as required for #91 and #25.

This should also unblock #101 providing unified handling for elements without any content and attributes.

By pure serendipity this also fixes tests introduced in #38.