### PR TITLE
Add support for kebab-case KeyDecodingStrategy

### DIFF
--- a/Sources/XMLCoder/Auxiliaries/String+Extensions.swift
+++ b/Sources/XMLCoder/Auxiliaries/String+Extensions.swift
@@ -21,7 +21,7 @@ extension StringProtocol where Self.Index == String.Index {
 
 extension StringProtocol {
     func capitalizingFirstLetter() -> Self {
-        guard count > 0 else {
+        guard !isEmpty else {
             return self
         }
         return Self(prefix(1).uppercased() + dropFirst())!

--- a/Sources/XMLCoder/Auxiliaries/String+Extensions.swift
+++ b/Sources/XMLCoder/Auxiliaries/String+Extensions.swift
@@ -21,7 +21,7 @@ extension StringProtocol where Self.Index == String.Index {
 
 extension StringProtocol {
     func capitalizingFirstLetter() -> Self {
-        guard count > 1 else {
+        guard count > 0 else {
             return self
         }
         return Self(prefix(1).uppercased() + dropFirst())!

--- a/Sources/XMLCoder/Decoder/XMLKeyedDecodingContainer.swift
+++ b/Sources/XMLCoder/Decoder/XMLKeyedDecodingContainer.swift
@@ -59,6 +59,10 @@ struct XMLKeyedDecodingContainer<K: CodingKey>: KeyedDecodingContainerProtocol {
             self.container = mapKeys(container) { key in
                 XMLDecoder.KeyDecodingStrategy._convertFromSnakeCase(key)
             }
+        case .convertFromKebabCase:
+            self.container = mapKeys(container) { key in
+                XMLDecoder.KeyDecodingStrategy._convertFromKebabCase(key)
+            }
         case .convertFromCapitalized:
             self.container = mapKeys(container) { key in
                 XMLDecoder.KeyDecodingStrategy._convertFromCapitalized(key)

--- a/Sources/XMLCoder/Encoder/XMLEncoder.swift
+++ b/Sources/XMLCoder/Encoder/XMLEncoder.swift
@@ -123,6 +123,10 @@ open class XMLEncoder {
         /// - Note: Using a key encoding strategy has a nominal performance cost, as each string key has to be converted.
         case convertToSnakeCase
 
+        /// Same as convertToSnakeCase, but using `-` instead of `_`
+        /// For example, `oneTwoThree` becomes `one-two-three`. `_oneTwoThree_` becomes `-one-two-three-`.
+        case convertToKebabCase
+
         /// Capitalize the first letter only
         /// `oneTwoThree` becomes  `OneTwoThree`
         case capitalized
@@ -198,6 +202,10 @@ open class XMLEncoder {
                 stringKey[range].lowercased()
             }.joined(separator: "_")
             return result
+        }
+
+        static func _convertToKebabCase(_ stringKey: String) -> String {
+            return _convertToSnakeCase(stringKey).replacingOccurrences(of: "_", with: "-")
         }
 
         static func _convertToCapitalized(_ stringKey: String) -> String {

--- a/Sources/XMLCoder/Encoder/XMLEncoder.swift
+++ b/Sources/XMLCoder/Encoder/XMLEncoder.swift
@@ -124,7 +124,7 @@ open class XMLEncoder {
         case convertToSnakeCase
 
         /// Same as convertToSnakeCase, but using `-` instead of `_`
-        /// For example, `oneTwoThree` becomes `one-two-three`. `_oneTwoThree_` becomes `-one-two-three-`.
+        /// For example, `oneTwoThree` becomes `one-two-three`.
         case convertToKebabCase
 
         /// Capitalize the first letter only
@@ -150,6 +150,14 @@ open class XMLEncoder {
         case custom((_ codingPath: [CodingKey]) -> CodingKey)
 
         static func _convertToSnakeCase(_ stringKey: String) -> String {
+            return _convert(stringKey, usingSeparator: "_")
+        }
+
+        static func _convertToKebabCase(_ stringKey: String) -> String {
+            return _convert(stringKey, usingSeparator: "-")
+        }
+
+        static func _convert(_ stringKey: String, usingSeparator separator: String) -> String {
             guard !stringKey.isEmpty else {
                 return stringKey
             }
@@ -200,12 +208,8 @@ open class XMLEncoder {
             words.append(wordStart..<searchRange.upperBound)
             let result = words.map { range in
                 stringKey[range].lowercased()
-            }.joined(separator: "_")
+            }.joined(separator: separator)
             return result
-        }
-
-        static func _convertToKebabCase(_ stringKey: String) -> String {
-            return _convertToSnakeCase(stringKey).replacingOccurrences(of: "_", with: "-")
         }
 
         static func _convertToCapitalized(_ stringKey: String) -> String {

--- a/Sources/XMLCoder/Encoder/XMLKeyedEncodingContainer.swift
+++ b/Sources/XMLCoder/Encoder/XMLKeyedEncodingContainer.swift
@@ -44,6 +44,10 @@ struct XMLKeyedEncodingContainer<K: CodingKey>: KeyedEncodingContainerProtocol {
             let newKeyString = XMLEncoder.KeyEncodingStrategy
                 ._convertToSnakeCase(key.stringValue)
             return XMLKey(stringValue: newKeyString, intValue: key.intValue)
+        case .convertToKebabCase:
+            let newKeyString = XMLEncoder.KeyEncodingStrategy
+                ._convertToKebabCase(key.stringValue)
+            return XMLKey(stringValue: newKeyString, intValue: key.intValue)
         case let .custom(converter):
             return converter(codingPath + [key])
         case .capitalized:

--- a/Tests/XMLCoderTests/KeyDecodingAndEncodingStrategyTests.swift
+++ b/Tests/XMLCoderTests/KeyDecodingAndEncodingStrategyTests.swift
@@ -32,7 +32,7 @@ private struct KebabCaseItem: Codable, Equatable {
     }
 }
 
-final class KeyDecodingStrategyTest: XCTestCase {
+final class KeyDecodingAndEncodingStrategyTests: XCTestCase {
     func testCapitalized() throws {
         let decoder = XMLDecoder()
         decoder.keyDecodingStrategy = .convertFromCapitalized

--- a/Tests/XMLCoderTests/KeyDecodingStrategyTest.swift
+++ b/Tests/XMLCoderTests/KeyDecodingStrategyTest.swift
@@ -12,7 +12,7 @@ private let capitalized = """
 <si><T>blah</T></si>
 """.data(using: .utf8)!
 
-private struct Item: Codable, Equatable {
+private struct CapitalizedItem: Codable, Equatable {
     public let text: String
 
     enum CodingKeys: String, CodingKey {
@@ -20,11 +20,40 @@ private struct Item: Codable, Equatable {
     }
 }
 
+private let kebabCase = """
+<si><tag-name>blah</tag-name></si>
+""".data(using: .utf8)!
+
+private struct KebabCaseItem: Codable, Equatable {
+    public let text: String
+
+    enum CodingKeys: String, CodingKey {
+        case text = "tagName"
+    }
+}
+
 final class KeyDecodingStrategyTest: XCTestCase {
     func testCapitalized() throws {
         let decoder = XMLDecoder()
         decoder.keyDecodingStrategy = .convertFromCapitalized
-        let result = try decoder.decode(Item.self, from: capitalized)
-        XCTAssertEqual(result.text, "blah")
+        let decodedResult = try decoder.decode(CapitalizedItem.self, from: capitalized)
+        XCTAssertEqual(decodedResult.text, "blah")
+
+        let encoder = XMLEncoder()
+        encoder.keyEncodingStrategy = .capitalized
+        let encodedResult = try encoder.encode(decodedResult, withRootKey: "si")
+        XCTAssertEqual(encodedResult, capitalized)
+    }
+
+    func testKebabCase() throws {
+        let decoder = XMLDecoder()
+        decoder.keyDecodingStrategy = .convertFromKebabCase
+        let decodedResult = try decoder.decode(KebabCaseItem.self, from: kebabCase)
+        XCTAssertEqual(decodedResult.text, "blah")
+
+        let encoder = XMLEncoder()
+        encoder.keyEncodingStrategy = .convertToKebabCase
+        let encodedResult = try encoder.encode(decodedResult, withRootKey: "si")
+        XCTAssertEqual(encodedResult, kebabCase)
     }
 }

--- a/XMLCoder.xcodeproj/project.pbxproj
+++ b/XMLCoder.xcodeproj/project.pbxproj
@@ -89,7 +89,7 @@
 		D158F12F2229892C0032B449 /* DynamicNodeDecoding.swift in Sources */ = {isa = PBXBuildFile; fileRef = D158F12E2229892C0032B449 /* DynamicNodeDecoding.swift */; };
 		D162674321F9B2AF0056D1D8 /* OptionalTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D162674121F9B2850056D1D8 /* OptionalTests.swift */; };
 		D1761D1F2247F04500F53CEF /* DynamicNodeDecodingTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = D1761D1E2247F04500F53CEF /* DynamicNodeDecodingTest.swift */; };
-		D1A3D4AD227AD9BF00F28969 /* KeyDecodingStrategyTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = D1A3D4AB227AD9BC00F28969 /* KeyDecodingStrategyTest.swift */; };
+		D1A3D4AD227AD9BF00F28969 /* KeyDecodingAndEncodingStrategyTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D1A3D4AB227AD9BC00F28969 /* KeyDecodingAndEncodingStrategyTests.swift */; };
 		D1AC9466224E3E63004AB49B /* AttributedEnumIntrinsicTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = D1AC9464224E3E1F004AB49B /* AttributedEnumIntrinsicTest.swift */; };
 		D1B6A2C22297EF6F005B8A6E /* BorderTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = D1B6A2C02297EF5A005B8A6E /* BorderTest.swift */; };
 		D1CAD3622293FAB80077901D /* MixedContainerTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = D1CAD3612293FAB80077901D /* MixedContainerTest.swift */; };
@@ -214,7 +214,7 @@
 		D158F12E2229892C0032B449 /* DynamicNodeDecoding.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DynamicNodeDecoding.swift; sourceTree = "<group>"; };
 		D162674121F9B2850056D1D8 /* OptionalTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OptionalTests.swift; sourceTree = "<group>"; };
 		D1761D1E2247F04500F53CEF /* DynamicNodeDecodingTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DynamicNodeDecodingTest.swift; sourceTree = "<group>"; };
-		D1A3D4AB227AD9BC00F28969 /* KeyDecodingStrategyTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KeyDecodingStrategyTest.swift; sourceTree = "<group>"; };
+		D1A3D4AB227AD9BC00F28969 /* KeyDecodingAndEncodingStrategyTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KeyDecodingAndEncodingStrategyTests.swift; sourceTree = "<group>"; };
 		D1AC9464224E3E1F004AB49B /* AttributedEnumIntrinsicTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AttributedEnumIntrinsicTest.swift; sourceTree = "<group>"; };
 		D1B6A2C02297EF5A005B8A6E /* BorderTest.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = BorderTest.swift; sourceTree = "<group>"; };
 		D1CAD3612293FAB80077901D /* MixedContainerTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MixedContainerTest.swift; sourceTree = "<group>"; };
@@ -418,7 +418,7 @@
 				OBJ_37 /* RJITest.swift */,
 				D14D8A8521F1D6B300B0D31A /* SingleChildTests.swift */,
 				D11815BF227788BA008836E4 /* SpacePreserveTest.swift */,
-				D1A3D4AB227AD9BC00F28969 /* KeyDecodingStrategyTest.swift */,
+				D1A3D4AB227AD9BC00F28969 /* KeyDecodingAndEncodingStrategyTests.swift */,
 				D1CAD3612293FAB80077901D /* MixedContainerTest.swift */,
 			);
 			name = XMLCoderTests;
@@ -681,7 +681,7 @@
 				BF9457CF21CBB516005ACFDE /* IntBoxTests.swift in Sources */,
 				BF9457E021CBB68A005ACFDE /* DataBoxTests.swift in Sources */,
 				D162674321F9B2AF0056D1D8 /* OptionalTests.swift in Sources */,
-				D1A3D4AD227AD9BF00F28969 /* KeyDecodingStrategyTest.swift in Sources */,
+				D1A3D4AD227AD9BF00F28969 /* KeyDecodingAndEncodingStrategyTests.swift in Sources */,
 				BF9457F521CBB6BC005ACFDE /* DecimalTests.swift in Sources */,
 				OBJ_83 /* CDTest.swift in Sources */,
 				BF63EF6721D0F874001D38C5 /* XMLKeyTests.swift in Sources */,


### PR DESCRIPTION
See: https://en.wikipedia.org/wiki/Letter_case#Special_case_styles

It would also be nice to make all the `convert...` functions declared under `KeyEncodingStrategy` and `KeyDecodingStrategy` public, so consumers can use them when performing a custom conversion.

I will be adding tests in case this contribution is desired.