### PR TITLE
Keep the order of the attributes during encoding operations

### DIFF
--- a/Sources/XMLCoder/Auxiliaries/XMLCoderElement.swift
+++ b/Sources/XMLCoder/Auxiliaries/XMLCoderElement.swift
@@ -13,8 +13,8 @@ struct Attribute: Equatable {
 }
 
 struct XMLCoderElement: Equatable {
-    static let attributesKey = "___ATTRIBUTES"
-    static let escapedCharacterSet = [
+    private static let attributesKey = "___ATTRIBUTES"
+    private static let escapedCharacterSet = [
         ("&", "&amp;"),
         ("<", "&lt;"),
         (">", "&gt;"),
@@ -22,10 +22,10 @@ struct XMLCoderElement: Equatable {
         ("\"", "&quot;"),
     ]
 
-    var key: String
-    var value: String?
-    var elements: [XMLCoderElement] = []
-    var attributes: [Attribute] = []
+    let key: String
+    private(set) var value: String?
+    private(set) var elements: [XMLCoderElement] = []
+    private(set) var attributes: [Attribute] = []
 
     init(
         key: String,

--- a/Sources/XMLCoder/Auxiliaries/XMLStackParser.swift
+++ b/Sources/XMLCoder/Auxiliaries/XMLStackParser.swift
@@ -126,7 +126,10 @@ extension XMLStackParser: XMLParserDelegate {
                 namespaceURI: String?,
                 qualifiedName: String?,
                 attributes attributeDict: [String: String] = [:]) {
-        let element = XMLCoderElement(key: elementName, attributes: attributeDict)
+        let attributes = attributeDict.map { key, value in
+            Attribute(key: key, value: value)
+        }
+        let element = XMLCoderElement(key: elementName, attributes: attributes)
         stack.append(element)
     }
 

--- a/Tests/XMLCoderTests/Auxiliary/XMLElementTests.swift
+++ b/Tests/XMLCoderTests/Auxiliary/XMLElementTests.swift
@@ -15,7 +15,7 @@ class XMLElementTests: XCTestCase {
         XCTAssertEqual(null.key, "foo")
         XCTAssertNil(null.value)
         XCTAssertEqual(null.elements, [])
-        XCTAssertEqual(null.attributes, [:])
+        XCTAssertEqual(null.attributes, [])
     }
 
     func testInitUnkeyed() {
@@ -24,7 +24,7 @@ class XMLElementTests: XCTestCase {
         XCTAssertEqual(keyed.key, "foo")
         XCTAssertNil(keyed.value)
         XCTAssertEqual(keyed.elements, [])
-        XCTAssertEqual(keyed.attributes, [:])
+        XCTAssertEqual(keyed.attributes, [])
     }
 
     func testInitKeyed() {
@@ -36,7 +36,7 @@ class XMLElementTests: XCTestCase {
         XCTAssertEqual(keyed.key, "foo")
         XCTAssertNil(keyed.value)
         XCTAssertEqual(keyed.elements, [])
-        XCTAssertEqual(keyed.attributes, ["blee": "42"])
+        XCTAssertEqual(keyed.attributes, [Attribute(key: "blee", value: "42")])
     }
 
     func testInitSimple() {
@@ -45,6 +45,6 @@ class XMLElementTests: XCTestCase {
         XCTAssertEqual(keyed.key, "foo")
         XCTAssertEqual(keyed.value, "bar")
         XCTAssertEqual(keyed.elements, [])
-        XCTAssertEqual(keyed.attributes, [:])
+        XCTAssertEqual(keyed.attributes, [])
     }
 }

--- a/Tests/XMLCoderTests/DynamicNodeDecodingTest.swift
+++ b/Tests/XMLCoderTests/DynamicNodeDecodingTest.swift
@@ -21,14 +21,18 @@ private let overlappingKeys = """
 private let libraryXMLYN = """
 <?xml version="1.0" encoding="UTF-8"?>
 <library count="2">
-    <book id="123">
+    <book id="123" author="Jack" gender="novel">
         <id>123</id>
+        <author>Jack</author>
+        <gender>novel</gender>
         <title>Cat in the Hat</title>
         <category main="Y"><value>Kids</value></category>
         <category main="N"><value>Wildlife</value></category>
     </book>
-    <book id="456">
+    <book id="456" author="Susan" gender="fantastic">
         <id>456</id>
+        <author>Susan</author>
+        <gender>fantastic</gender>
         <title>1984</title>
         <category main="Y"><value>Classics</value></category>
         <category main="N"><value>News</value></category>
@@ -42,6 +46,8 @@ private let libraryXMLYNStrategy = """
     <count>2</count>
     <book title="Cat in the Hat">
         <id>123</id>
+        <author>Jack</author>
+        <gender>novel</gender>
         <category>
             <main>true</main>
             <value>Kids</value>
@@ -53,6 +59,8 @@ private let libraryXMLYNStrategy = """
     </book>
     <book title="1984">
         <id>456</id>
+        <author>Susan</author>
+        <gender>fantastic</gender>
         <category>
             <main>true</main>
             <value>Classics</value>
@@ -109,18 +117,22 @@ private struct Library: Codable, Equatable, DynamicNodeDecoding {
 
 private struct Book: Codable, Equatable, DynamicNodeEncoding {
     let id: UInt
+    let author: String
+    let gender: String
     let title: String
     let categories: [Category]
 
     enum CodingKeys: String, CodingKey {
         case id
+        case author
+        case gender
         case title
         case categories = "category"
     }
 
     static func nodeEncoding(for key: CodingKey) -> XMLEncoder.NodeEncoding {
         switch key {
-        case Book.CodingKeys.id: return .both
+        case Book.CodingKeys.id, Book.CodingKeys.author, Book.CodingKeys.gender: return .both
         default: return .element
         }
     }

--- a/Tests/XMLCoderTests/DynamicNodeEncodingTest.swift
+++ b/Tests/XMLCoderTests/DynamicNodeEncodingTest.swift
@@ -12,14 +12,18 @@ import XCTest
 private let libraryXMLYN = """
 <?xml version="1.0" encoding="UTF-8"?>
 <library count="2">
-    <book id="123">
+    <book id="123" author="Jack" gender="novel">
         <id>123</id>
+        <author>Jack</author>
+        <gender>novel</gender>
         <title>Cat in the Hat</title>
         <category main="Y"><value>Kids</value></category>
         <category main="N"><value>Wildlife</value></category>
     </book>
-    <book id="456">
+    <book id="456" author="Susan" gender="fantastic">
         <id>456</id>
+        <author>Susan</author>
+        <gender>fantastic</gender>
         <title>1984</title>
         <category main="Y"><value>Classics</value></category>
         <category main="N"><value>News</value></category>
@@ -33,6 +37,8 @@ private let libraryXMLYNStrategy = """
     <count>2</count>
     <book title="Cat in the Hat">
         <id>123</id>
+        <author>Jack</author>
+        <gender>novel</gender>
         <category>
             <main>true</main>
             <value>Kids</value>
@@ -44,6 +50,8 @@ private let libraryXMLYNStrategy = """
     </book>
     <book title="1984">
         <id>456</id>
+        <author>Susan</author>
+        <gender>fantastic</gender>
         <category>
             <main>true</main>
             <value>Classics</value>
@@ -60,8 +68,10 @@ private let libraryXMLTrueFalse = """
 <?xml version="1.0" encoding="UTF-8"?>
 <library>
     <count>2</count>
-    <book id="123">
+    <book id="123" author="Jack" gender="novel">
         <id>123</id>
+        <author>Jack</author>
+        <gender>novel</gender>
         <title>Cat in the Hat</title>
         <category main="true">
             <value>Kids</value>
@@ -70,8 +80,10 @@ private let libraryXMLTrueFalse = """
             <value>Wildlife</value>
         </category>
     </book>
-    <book id="456">
+    <book id="456" author="Susan" gender="fantastic">
         <id>456</id>
+        <author>Susan</author>
+        <gender>fantastic</gender>
         <title>1984</title>
         <category main="true">
             <value>Classics</value>
@@ -95,18 +107,22 @@ private struct Library: Codable, Equatable {
 
 private struct Book: Codable, Equatable, DynamicNodeEncoding {
     let id: UInt
+    let author: String
+    let gender: String
     let title: String
     let categories: [Category]
 
     enum CodingKeys: String, CodingKey {
         case id
+        case author
+        case gender
         case title
         case categories = "category"
     }
 
     static func nodeEncoding(for key: CodingKey) -> XMLEncoder.NodeEncoding {
         switch key {
-        case Book.CodingKeys.id: return .both
+        case Book.CodingKeys.id, Book.CodingKeys.author, Book.CodingKeys.gender: return .both
         default: return .element
         }
     }
@@ -135,6 +151,8 @@ final class DynamicNodeEncodingTest: XCTestCase {
     func testEncode() throws {
         let book1 = Book(
             id: 123,
+            author: "Jack",
+            gender: "novel",
             title: "Cat in the Hat",
             categories: [
                 Category(main: true, value: "Kids"),
@@ -144,6 +162,8 @@ final class DynamicNodeEncodingTest: XCTestCase {
 
         let book2 = Book(
             id: 456,
+            author: "Susan",
+            gender: "fantastic",
             title: "1984",
             categories: [
                 Category(main: true, value: "Classics"),

--- a/Tests/XMLCoderTests/Minimal/BoxTreeTests.swift
+++ b/Tests/XMLCoderTests/Minimal/BoxTreeTests.swift
@@ -14,19 +14,19 @@ class BoxTreeTests: XCTestCase {
             key: "foo",
             value: "456",
             elements: [],
-            attributes: ["id": "123"]
+            attributes: [Attribute(key: "id", value: "123")]
         )
         let e2 = XMLCoderElement(
             key: "foo",
             value: "123",
             elements: [],
-            attributes: ["id": "789"]
+            attributes: [Attribute(key: "id", value: "789")]
         )
         let root = XMLCoderElement(
             key: "container",
             value: nil,
             elements: [e1, e2],
-            attributes: [:]
+            attributes: []
         )
 
         let boxTree = root.transformToBoxTree()


### PR DESCRIPTION
This PR fixes https://github.com/MaxDesiatov/XMLCoder/issues/108 by replacing the unordered data structure used for storing the attributes (a Swift `Dictionary`) with an ordered data structure: an array of `Attribute` structs.