### PR TITLE
[WIP / Proof of concept] Add Decoding support for enums with associated values

### DIFF
--- a/Sources/XMLCoder/Auxiliaries/XMLCoderElement.swift
+++ b/Sources/XMLCoder/Auxiliaries/XMLCoderElement.swift
@@ -230,7 +230,9 @@ struct XMLCoderElement: Equatable {
                 string += "</\(key)>"
             }
         } else if !elements.isEmpty {
-            string += prettyPrinted ? ">\n" : ">"
+            if !key.isEmpty {
+                string += prettyPrinted ? ">\n" : ">"
+            }
             formatXMLElements(formatting, &string, level, cdata, prettyPrinted)
 
             string += indentation
@@ -250,7 +252,7 @@ struct XMLCoderElement: Equatable {
 extension XMLCoderElement {
     init(key: String, box: UnkeyedBox) {
         self.init(key: key, elements: box.map {
-            XMLCoderElement(key: key, box: $0)
+            XMLCoderElement(key: "", box: $0)
         })
     }
 

--- a/Sources/XMLCoder/Auxiliaries/XMLCoderElement.swift
+++ b/Sources/XMLCoder/Auxiliaries/XMLCoderElement.swift
@@ -62,7 +62,6 @@ struct XMLCoderElement: Equatable {
         if let value = value, elements.isEmpty, attributes.isEmpty {
             elements.append(StringBox(value), at: key)
         }
-        
         // Handle attributed unkeyed value <foo attr="bar">zap</foo>
         // Value should be zap. Detect only when no other elements exist
         if elements.isEmpty, let value = value {

--- a/Sources/XMLCoder/Auxiliaries/XMLCoderElement.swift
+++ b/Sources/XMLCoder/Auxiliaries/XMLCoderElement.swift
@@ -58,6 +58,11 @@ struct XMLCoderElement: Equatable {
         let storage = KeyedStorage<String, Box>()
         var elements = self.elements.reduce(storage) { $0.merge(element: $1) }
 
+        // Handle enum with associated value case, in which there are no attributes _or_ elements.
+        if let value = value, elements.isEmpty, attributes.isEmpty {
+            elements.append(StringBox(value), at: key)
+        }
+        
         // Handle attributed unkeyed value <foo attr="bar">zap</foo>
         // Value should be zap. Detect only when no other elements exist
         if elements.isEmpty, let value = value {

--- a/Sources/XMLCoder/Decoder/XMLDecoderImplementation.swift
+++ b/Sources/XMLCoder/Decoder/XMLDecoderImplementation.swift
@@ -384,7 +384,6 @@ extension XMLDecoderImplementation {
     }
 
     func unbox<T: Decodable>(_ box: Box) throws -> T {
-
         let decoded: T?
         let type = T.self
 

--- a/Sources/XMLCoder/Decoder/XMLDecoderImplementation.swift
+++ b/Sources/XMLCoder/Decoder/XMLDecoderImplementation.swift
@@ -141,8 +141,6 @@ class XMLDecoderImplementation: Decoder {
             // In order to support decoding enums with associated values, transform the `keyed` box
             // into an unkeyed box composed of a single key-valued `KeyedBox` element for each
             // key-value pair found in the original.
-            //
-            // NB: This currently breaks `testDecodeUnkeyedWithinUnkeyed()`.
             return XMLUnkeyedDecodingContainer(
                 referencing: self,
                 wrapping: keyed.withShared {

--- a/Sources/XMLCoder/Decoder/XMLDecoderImplementation.swift
+++ b/Sources/XMLCoder/Decoder/XMLDecoderImplementation.swift
@@ -146,8 +146,9 @@ class XMLDecoderImplementation: Decoder {
             return XMLUnkeyedDecodingContainer(
                 referencing: self,
                 wrapping: keyed.withShared {
-                    SharedBox($0.elements.map { (key, element) in
-                        KeyedBox(elements: KeyedStorage([(key, element)]), attributes: .init()) }
+                    SharedBox($0.elements.map { key, element in
+                        KeyedBox(elements: KeyedStorage([(key, element)]), attributes: .init())
+                    }
                     )
                 }
             )

--- a/Sources/XMLCoder/Decoder/XMLDecoderImplementation.swift
+++ b/Sources/XMLCoder/Decoder/XMLDecoderImplementation.swift
@@ -147,7 +147,7 @@ class XMLDecoderImplementation: Decoder {
                 referencing: self,
                 wrapping: keyed.withShared {
                     SharedBox($0.elements.map { (key, element) in
-                        KeyedBox(elements: KeyedStorage([(key, element)])) }
+                        KeyedBox(elements: KeyedStorage([(key, element)]), attributes: .init()) }
                     )
                 }
             )

--- a/Sources/XMLCoder/Decoder/XMLDecoderImplementation.swift
+++ b/Sources/XMLCoder/Decoder/XMLDecoderImplementation.swift
@@ -384,6 +384,7 @@ extension XMLDecoderImplementation {
     }
 
     func unbox<T: Decodable>(_ box: Box) throws -> T {
+
         let decoded: T?
         let type = T.self
 

--- a/Sources/XMLCoder/Decoder/XMLDecoderImplementation.swift
+++ b/Sources/XMLCoder/Decoder/XMLDecoderImplementation.swift
@@ -146,7 +146,9 @@ class XMLDecoderImplementation: Decoder {
             return XMLUnkeyedDecodingContainer(
                 referencing: self,
                 wrapping: keyed.withShared {
-                    SharedBox($0.elements.map { KeyedBox(elements: KeyedStorage([$0])) })
+                    SharedBox($0.elements.map { (key, element) in
+                        KeyedBox(elements: KeyedStorage([(key, element)])) }
+                    )
                 }
             )
         default:

--- a/Sources/XMLCoder/Decoder/XMLUnkeyedDecodingContainer.swift
+++ b/Sources/XMLCoder/Decoder/XMLUnkeyedDecodingContainer.swift
@@ -107,14 +107,8 @@ struct XMLUnkeyedDecodingContainer: UnkeyedDecodingContainer {
         // performed an injection of single key-valued `KeyedBox` elements in
         // XMLDecoderImplementation.unkeyedContainer(), and attempt to decode the single element
         // contained therein.
-        if value == nil, let keyed = box as? KeyedBox, !keyed.elements.isEmpty {
-            if keyed.elements.count == 1 {
-                // First, check to see if we need to decode single enum with associated value
-                value = try decode(decoder, keyed.elements[keyed.elements.keys[0]])
-            } else {
-                // Otherwise, we are looking at a nested array I think!
-                value = try decode(decoder, keyed.elements[keyed.elements.keys[0]])
-            }
+        if value == nil, let keyed = box as? KeyedBox, keyed.elements.count == 1 {
+            value = try decode(decoder, keyed.elements[keyed.elements.keys[0]][0])
         }
         defer { currentIndex += 1 }
 

--- a/Sources/XMLCoder/Decoder/XMLUnkeyedDecodingContainer.swift
+++ b/Sources/XMLCoder/Decoder/XMLUnkeyedDecodingContainer.swift
@@ -107,8 +107,12 @@ struct XMLUnkeyedDecodingContainer: UnkeyedDecodingContainer {
         // performed an injection of single key-valued `KeyedBox` elements in
         // XMLDecoderImplementation.unkeyedContainer(), and attempt to decode the single element
         // contained therein.
-        if value == nil {
-            if let keyed = box as? KeyedBox, !keyed.elements.isEmpty {
+        if value == nil, let keyed = box as? KeyedBox, !keyed.elements.isEmpty {
+            if keyed.elements.count == 1 {
+                // First, check to see if we need to decode single enum with associated value
+                value = try decode(decoder, keyed.elements[keyed.elements.keys[0]])
+            } else {
+                // Otherwise, we are looking at a nested array I think!
                 value = try decode(decoder, keyed.elements[keyed.elements.keys[0]])
             }
         }

--- a/Sources/XMLCoder/Decoder/XMLUnkeyedDecodingContainer.swift
+++ b/Sources/XMLCoder/Decoder/XMLUnkeyedDecodingContainer.swift
@@ -101,7 +101,7 @@ struct XMLUnkeyedDecodingContainer: UnkeyedDecodingContainer {
         let box = container.withShared { unkeyedBox in
             unkeyedBox[self.currentIndex]
         }
-        var value = try decode(decoder,box)
+        var value = try decode(decoder, box)
 
         // In order to support decoding enums with associated values, check to see if we have
         // performed an injection of single key-valued `KeyedBox` elements in

--- a/Sources/XMLCoder/Decoder/XMLUnkeyedDecodingContainer.swift
+++ b/Sources/XMLCoder/Decoder/XMLUnkeyedDecodingContainer.swift
@@ -101,9 +101,18 @@ struct XMLUnkeyedDecodingContainer: UnkeyedDecodingContainer {
         let box = container.withShared { unkeyedBox in
             unkeyedBox[self.currentIndex]
         }
+        var value = try decode(decoder,box)
 
-        let value = try decode(decoder, box)
-
+        // In order to support decoding enums with associated values, check to see if we have
+        // performed an injection of single key-valued `KeyedBox` elements in
+        // XMLDecoderImplementation.unkeyedContainer(), and attempt to decode the single element
+        // contained therein.
+        if value == nil {
+            if let keyed = box as? KeyedBox, keyed.elements.count == 1 {
+                value = try decode(decoder, keyed.elements[keyed.elements.keys[0]])
+            }
+        }
+        
         defer { currentIndex += 1 }
 
         if value == nil, let type = type as? AnyOptional.Type,

--- a/Sources/XMLCoder/Decoder/XMLUnkeyedDecodingContainer.swift
+++ b/Sources/XMLCoder/Decoder/XMLUnkeyedDecodingContainer.swift
@@ -108,7 +108,10 @@ struct XMLUnkeyedDecodingContainer: UnkeyedDecodingContainer {
         // XMLDecoderImplementation.unkeyedContainer(), and attempt to decode the single element
         // contained therein.
         if value == nil, let keyed = box as? KeyedBox, keyed.elements.count == 1 {
-            value = try decode(decoder, keyed.elements[keyed.elements.keys[0]][0])
+            let firstKey = keyed.elements.keys[0]
+            let firstElement = keyed.elements[firstKey]
+            let values = firstElement[0]
+            value = try decode(decoder, values)
         }
         defer { currentIndex += 1 }
 

--- a/Sources/XMLCoder/Decoder/XMLUnkeyedDecodingContainer.swift
+++ b/Sources/XMLCoder/Decoder/XMLUnkeyedDecodingContainer.swift
@@ -112,7 +112,6 @@ struct XMLUnkeyedDecodingContainer: UnkeyedDecodingContainer {
                 value = try decode(decoder, keyed.elements[keyed.elements.keys[0]])
             }
         }
-        
         defer { currentIndex += 1 }
 
         if value == nil, let type = type as? AnyOptional.Type,

--- a/Sources/XMLCoder/Decoder/XMLUnkeyedDecodingContainer.swift
+++ b/Sources/XMLCoder/Decoder/XMLUnkeyedDecodingContainer.swift
@@ -108,7 +108,7 @@ struct XMLUnkeyedDecodingContainer: UnkeyedDecodingContainer {
         // XMLDecoderImplementation.unkeyedContainer(), and attempt to decode the single element
         // contained therein.
         if value == nil {
-            if let keyed = box as? KeyedBox, keyed.elements.count == 1 {
+            if let keyed = box as? KeyedBox, !keyed.elements.isEmpty {
                 value = try decode(decoder, keyed.elements[keyed.elements.keys[0]])
             }
         }

--- a/Tests/XMLCoderTests/EnumAssociatedValueTestComposite.swift
+++ b/Tests/XMLCoderTests/EnumAssociatedValueTestComposite.swift
@@ -38,7 +38,6 @@ extension IntOrStringWrapper: Decodable {
     }
 }
 
-
 class EnumAssociatedValueTestComposite: XCTestCase {
 
     func testIntOrStringWrapper() throws {

--- a/Tests/XMLCoderTests/EnumAssociatedValueTestComposite.swift
+++ b/Tests/XMLCoderTests/EnumAssociatedValueTestComposite.swift
@@ -22,7 +22,6 @@ private enum IntOrStringWrapper: Equatable {
 }
 
 extension IntOrStringWrapper: Decodable {
-
     enum CodingKeys: String, CodingKey {
         case int
         case string
@@ -39,7 +38,6 @@ extension IntOrStringWrapper: Decodable {
 }
 
 class EnumAssociatedValueTestComposite: XCTestCase {
-
     func testIntOrStringWrapper() throws {
         let xml = """
         <container>

--- a/Tests/XMLCoderTests/EnumAssociatedValueTestComposite.swift
+++ b/Tests/XMLCoderTests/EnumAssociatedValueTestComposite.swift
@@ -1,0 +1,79 @@
+//
+//  EnumAssociatedValueTestComposite.swift
+//  XMLCoderTests
+//
+//  Created by James Bean on 7/12/19.
+//
+
+import XCTest
+import XMLCoder
+
+private struct IntWrapper: Decodable, Equatable {
+    let wrapped: Int
+}
+
+private struct StringWrapper: Decodable, Equatable {
+    let wrapped: String
+}
+
+private enum IntOrStringWrapper: Equatable {
+    case int(IntWrapper)
+    case string(StringWrapper)
+}
+
+extension IntOrStringWrapper: Decodable {
+
+    enum CodingKeys: String, CodingKey {
+        case int
+        case string
+    }
+
+    init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        do {
+            self = .int(try container.decode(IntWrapper.self, forKey: .int))
+        } catch {
+            self = .string(try container.decode(StringWrapper.self, forKey: .string))
+        }
+    }
+}
+
+
+class EnumAssociatedValueTestComposite: XCTestCase {
+
+    func testIntOrStringWrapper() throws {
+        let xml = """
+        <container>
+            <string>
+                <wrapped>A Word About Woke Times</wrapped>
+            </string>
+        </container>
+        """
+        let result = try XMLDecoder().decode(IntOrStringWrapper.self, from: xml.data(using: .utf8)!)
+        let expected = IntOrStringWrapper.string(StringWrapper(wrapped: "A Word About Woke Times"))
+        XCTAssertEqual(result, expected)
+    }
+
+    func testArrayOfIntOrStringWrappers() throws {
+        let xml = """
+        <container>
+            <string>
+                <wrapped>A Word About Woke Times</wrapped>
+            </string>
+            <int>
+                <wrapped>9000</wrapped>
+            </int>
+            <string>
+                <wrapped>A Word About Woke Tomes</wrapped>
+            </string>
+        </container>
+        """
+        let result = try XMLDecoder().decode([IntOrStringWrapper].self, from: xml.data(using: .utf8)!)
+        let expected: [IntOrStringWrapper] = [
+            .string(StringWrapper(wrapped: "A Word About Woke Times")),
+            .int(IntWrapper(wrapped: 9000)),
+            .string(StringWrapper(wrapped: "A Word About Woke Tomes")),
+        ]
+        XCTAssertEqual(result, expected)
+    }
+}

--- a/Tests/XMLCoderTests/EnumAssociatedValueTestSimple.swift
+++ b/Tests/XMLCoderTests/EnumAssociatedValueTestSimple.swift
@@ -14,12 +14,10 @@ private enum IntOrString {
 }
 
 extension IntOrString: Decodable {
-    
     enum CodingKeys: String, CodingKey {
         case int
         case string
     }
-    
     init(from decoder: Decoder) throws {
         let container = try decoder.container(keyedBy: CodingKeys.self)
         do {
@@ -33,21 +31,21 @@ extension IntOrString: Decodable {
 extension IntOrString: Equatable { }
 
 class EnumAssociatedValuesTest: XCTestCase {
-    
+
     func testIntOrStringIntDecoding() throws {
         let xml = "<int>42</int>"
         let result = try XMLDecoder().decode(IntOrString.self, from: xml.data(using: .utf8)!)
         let expected = IntOrString.int(42)
         XCTAssertEqual(result, expected)
     }
-    
+
     func testIntOrStringStringDecoding() throws {
         let xml = "<string>forty-two</string>"
         let result = try XMLDecoder().decode(IntOrString.self, from: xml.data(using: .utf8)!)
         let expected = IntOrString.string("forty-two")
         XCTAssertEqual(result, expected)
     }
-    
+
     func testIntOrStringArrayDecoding() throws {
         let xml = """
         <container>

--- a/Tests/XMLCoderTests/EnumAssociatedValueTestSimple.swift
+++ b/Tests/XMLCoderTests/EnumAssociatedValueTestSimple.swift
@@ -13,10 +13,21 @@ private enum IntOrString {
     case string(String)
 }
 
-extension IntOrString: Decodable {
+extension IntOrString: Codable {
+
     enum CodingKeys: String, CodingKey {
         case int
         case string
+    }
+
+    func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        switch self {
+        case .int(let value):
+            try container.encode(value, forKey: .int)
+        case .string(let value):
+            try container.encode(value, forKey: .string)
+        }
     }
 
     init(from decoder: Decoder) throws {
@@ -65,5 +76,12 @@ class EnumAssociatedValuesTest: XCTestCase {
             .int(5),
         ]
         XCTAssertEqual(result, expected)
+    }
+
+    func testIntOrStringEncoding() throws {
+        let original = IntOrString.int(5)
+        let encoded = try XMLEncoder().encode(original, withRootKey: "root")
+        let decoded = try XMLDecoder().decode(IntOrString.self, from: encoded)
+        XCTAssertEqual(original, decoded)
     }
 }

--- a/Tests/XMLCoderTests/EnumAssociatedValueTestSimple.swift
+++ b/Tests/XMLCoderTests/EnumAssociatedValueTestSimple.swift
@@ -78,10 +78,23 @@ class EnumAssociatedValuesTest: XCTestCase {
         XCTAssertEqual(result, expected)
     }
 
-    func testIntOrStringEncoding() throws {
+    func testIntOrStringRoundTrip() throws {
         let original = IntOrString.int(5)
-        let encoded = try XMLEncoder().encode(original, withRootKey: "root")
+        let encoded = try XMLEncoder().encode(original, withRootKey: "container")
         let decoded = try XMLDecoder().decode(IntOrString.self, from: encoded)
+        XCTAssertEqual(original, decoded)
+    }
+
+    func testIntOrStringArrayRoundTrip() throws {
+        let original: [IntOrString] = [
+            .int(1),
+            .string("two"),
+            .string("three"),
+            .int(4),
+            .int(5),
+        ]
+        let encoded = try XMLEncoder().encode(original, withRootKey: "container")
+        let decoded = try XMLDecoder().decode([IntOrString].self, from: encoded)
         XCTAssertEqual(original, decoded)
     }
 }

--- a/Tests/XMLCoderTests/EnumAssociatedValueTestSimple.swift
+++ b/Tests/XMLCoderTests/EnumAssociatedValueTestSimple.swift
@@ -1,0 +1,71 @@
+//
+//  EnumAssociatedValueTestSimple.swift
+//  XMLCoderTests
+//
+//  Created by James Bean on 7/9/19.
+//
+
+import XCTest
+import XMLCoder
+
+private enum IntOrString {
+    case int(Int)
+    case string(String)
+}
+
+extension IntOrString: Decodable {
+    
+    enum CodingKeys: String, CodingKey {
+        case int
+        case string
+    }
+    
+    init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        do {
+            self = .int(try container.decode(Int.self, forKey: .int))
+        } catch {
+            self = .string(try container.decode(String.self, forKey: .string))
+        }
+    }
+}
+
+extension IntOrString: Equatable { }
+
+class EnumAssociatedValuesTest: XCTestCase {
+    
+    func testIntOrStringIntDecoding() throws {
+        let xml = "<int>42</int>"
+        let result = try XMLDecoder().decode(IntOrString.self, from: xml.data(using: .utf8)!)
+        let expected = IntOrString.int(42)
+        XCTAssertEqual(result, expected)
+    }
+    
+    func testIntOrStringStringDecoding() throws {
+        let xml = "<string>forty-two</string>"
+        let result = try XMLDecoder().decode(IntOrString.self, from: xml.data(using: .utf8)!)
+        let expected = IntOrString.string("forty-two")
+        XCTAssertEqual(result, expected)
+    }
+    
+    func testIntOrStringArrayDecoding() throws {
+        let xml = """
+        <container>
+            <int>1</int>
+            <string>two</string>
+            <string>three</string>
+            <int>4</int>
+            <int>5</int>
+        </container>
+        """
+        let result = try XMLDecoder().decode([IntOrString].self, from: xml.data(using: .utf8)!)
+        let expected: [IntOrString] = [
+            .int(1),
+            .string("two"),
+            .string("three"),
+            .int(4),
+            .int(5),
+        ]
+        XCTAssertEqual(result, expected)
+    }
+}

--- a/Tests/XMLCoderTests/EnumAssociatedValueTestSimple.swift
+++ b/Tests/XMLCoderTests/EnumAssociatedValueTestSimple.swift
@@ -18,6 +18,7 @@ extension IntOrString: Decodable {
         case int
         case string
     }
+
     init(from decoder: Decoder) throws {
         let container = try decoder.container(keyedBy: CodingKeys.self)
         do {
@@ -28,10 +29,9 @@ extension IntOrString: Decodable {
     }
 }
 
-extension IntOrString: Equatable { }
+extension IntOrString: Equatable {}
 
 class EnumAssociatedValuesTest: XCTestCase {
-
     func testIntOrStringIntDecoding() throws {
         let xml = "<int>42</int>"
         let result = try XMLDecoder().decode(IntOrString.self, from: xml.data(using: .utf8)!)

--- a/Tests/XMLCoderTests/NestedEnumAssociatedValueTest.swift
+++ b/Tests/XMLCoderTests/NestedEnumAssociatedValueTest.swift
@@ -32,7 +32,7 @@ private struct Properties: Decodable, Equatable {
     let title: String
 }
 
-private struct Break: Decodable, Equatable { }
+private struct Break: Decodable, Equatable {}
 
 extension Container: Decodable {
     private enum CodingKeys: String, CodingKey {
@@ -43,7 +43,7 @@ extension Container: Decodable {
 extension Paragraph: Decodable {
     init(from decoder: Decoder) throws {
         let container = try decoder.singleValueContainer()
-        self.entries = try container.decode([Entry].self)
+        entries = try container.decode([Entry].self)
     }
 }
 
@@ -51,6 +51,7 @@ extension Entry: Decodable {
     private enum CodingKeys: String, CodingKey {
         case run, properties, br
     }
+
     public init(from decoder: Decoder) throws {
         let container = try decoder.container(keyedBy: CodingKeys.self)
         do {
@@ -66,7 +67,6 @@ extension Entry: Decodable {
 }
 
 class NestedEnumAssociatedValueTest: XCTestCase {
-
     func testBreakDecoding() throws {
         let xml = "<br></br>"
         let result = try XMLDecoder().decode(Break.self, from: xml.data(using: .utf8)!)
@@ -142,7 +142,7 @@ class NestedEnumAssociatedValueTest: XCTestCase {
         let result = try XMLDecoder().decode([Entry].self, from: xml.data(using: .utf8)!)
         let expected: [Entry] = [
             .run(Run(id: 1518, text: "I am answering it again.")),
-            .properties(Properties(id: 431, title: "A Word About Wake Times"))
+            .properties(Properties(id: 431, title: "A Word About Wake Times")),
         ]
         XCTAssertEqual(result, expected)
     }
@@ -164,7 +164,7 @@ class NestedEnumAssociatedValueTest: XCTestCase {
         let expected = Paragraph(
             entries: [
                 .run(Run(id: 1518, text: "I am answering it again.")),
-                .properties(Properties(id: 431, title: "A Word About Wake Times"))
+                .properties(Properties(id: 431, title: "A Word About Wake Times")),
             ]
         )
         XCTAssertEqual(result, expected)
@@ -204,7 +204,7 @@ class NestedEnumAssociatedValueTest: XCTestCase {
                     entries: [
                         .run(Run(id: 1519, text: "I am answering it again.")),
                     ]
-                )
+                ),
             ]
         )
         XCTAssertEqual(result, expected)

--- a/Tests/XMLCoderTests/NestedEnumAssociatedValueTest.swift
+++ b/Tests/XMLCoderTests/NestedEnumAssociatedValueTest.swift
@@ -1,0 +1,212 @@
+//
+//  NestedEnumAssociatedValueTest.swift
+//  XMLCoderTests
+//
+//  Created by James Bean on 7/11/19.
+//
+
+import XCTest
+import XMLCoder
+
+private struct Container: Equatable {
+    let paragraphs: [Paragraph]
+}
+
+private struct Paragraph: Equatable {
+    let entries: [Entry]
+}
+
+private enum Entry: Equatable {
+    case run(Run)
+    case properties(Properties)
+    case br(Break)
+}
+
+private struct Run: Decodable, Equatable {
+    let id: Int
+    let text: String
+}
+
+private struct Properties: Decodable, Equatable {
+    let id: Int
+    let title: String
+}
+
+private struct Break: Decodable, Equatable { }
+
+extension Container: Decodable {
+    private enum CodingKeys: String, CodingKey {
+        case paragraphs = "p"
+    }
+}
+
+extension Paragraph: Decodable {
+    init(from decoder: Decoder) throws {
+        let container = try decoder.singleValueContainer()
+        self.entries = try container.decode([Entry].self)
+    }
+}
+
+extension Entry: Decodable {
+    private enum CodingKeys: String, CodingKey {
+        case run, properties, br
+    }
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        do {
+            self = .run(try container.decode(Run.self, forKey: .run))
+        } catch DecodingError.keyNotFound {
+            do {
+                self = .properties(try container.decode(Properties.self, forKey: .properties))
+            } catch DecodingError.keyNotFound {
+                self = .br(try container.decode(Break.self, forKey: .br))
+            }
+        }
+    }
+}
+
+class NestedEnumAssociatedValueTest: XCTestCase {
+
+    func testBreakDecoding() throws {
+        let xml = "<br></br>"
+        let result = try XMLDecoder().decode(Break.self, from: xml.data(using: .utf8)!)
+        let expected = Break()
+        XCTAssertEqual(result, expected)
+    }
+
+    func testPropertiesDecoding() throws {
+        let xml = """
+        <properties>
+            <id>431</id>
+            <title>A Word About Wake Times</title>
+        </properties>
+        """
+        let result = try XMLDecoder().decode(Properties.self, from: xml.data(using: .utf8)!)
+        let expected = Properties(id: 431, title: "A Word About Wake Times")
+        XCTAssertEqual(result, expected)
+    }
+
+    func testPropertiesAsEntryDecoding() throws {
+        let xml = """
+        <entry>
+            <properties>
+                <id>431</id>
+                <title>A Word About Wake Times</title>
+            </properties>
+        </entry>
+        """
+        let result = try XMLDecoder().decode(Entry.self, from: xml.data(using: .utf8)!)
+        let expected: Entry = .properties(Properties(id: 431, title: "A Word About Wake Times"))
+        XCTAssertEqual(result, expected)
+    }
+
+    func testRunDecoding() throws {
+        let xml = """
+        <run>
+            <id>1518</id>
+            <text>I am answering it again.</text>
+        </run>
+        """
+        let result = try XMLDecoder().decode(Run.self, from: xml.data(using: .utf8)!)
+        let expected = Run(id: 1518, text: "I am answering it again.")
+        XCTAssertEqual(result, expected)
+    }
+
+    func testRunAsEntryDecoding() throws {
+        let xml = """
+        <entry>
+            <run>
+                <id>1518</id>
+                <text>I am answering it again.</text>
+            </run>
+        </entry>
+        """
+        let result = try XMLDecoder().decode(Entry.self, from: xml.data(using: .utf8)!)
+        let expected = Entry.run(Run(id: 1518, text: "I am answering it again."))
+        XCTAssertEqual(result, expected)
+    }
+
+    func testEntriesDecoding() throws {
+        let xml = """
+        <entries>
+            <run>
+                <id>1518</id>
+                <text>I am answering it again.</text>
+            </run>
+            <properties>
+                <id>431</id>
+                <title>A Word About Wake Times</title>
+            </properties>
+        </entries>
+        """
+        let result = try XMLDecoder().decode([Entry].self, from: xml.data(using: .utf8)!)
+        let expected: [Entry] = [
+            .run(Run(id: 1518, text: "I am answering it again.")),
+            .properties(Properties(id: 431, title: "A Word About Wake Times"))
+        ]
+        XCTAssertEqual(result, expected)
+    }
+
+    func testParagraphDecoding() throws {
+        let xml = """
+        <p>
+            <run>
+                <id>1518</id>
+                <text>I am answering it again.</text>
+            </run>
+            <properties>
+                <id>431</id>
+                <title>A Word About Wake Times</title>
+            </properties>
+        </p>
+        """
+        let result = try XMLDecoder().decode(Paragraph.self, from: xml.data(using: .utf8)!)
+        let expected = Paragraph(
+            entries: [
+                .run(Run(id: 1518, text: "I am answering it again.")),
+                .properties(Properties(id: 431, title: "A Word About Wake Times"))
+            ]
+        )
+        XCTAssertEqual(result, expected)
+    }
+
+    func testNestedEnums() throws {
+        let xml = """
+        <container>
+            <p>
+                <run>
+                    <id>1518</id>
+                    <text>I am answering it again.</text>
+                </run>
+                <properties>
+                    <id>431</id>
+                    <title>A Word About Wake Times</title>
+                </properties>
+            </p>
+            <p>
+                <run>
+                    <id>1519</id>
+                    <text>I am answering it again.</text>
+                </run>
+            </p>
+        </container>
+        """
+        let result = try XMLDecoder().decode(Container.self, from: xml.data(using: .utf8)!)
+        let expected = Container(
+            paragraphs: [
+                Paragraph(
+                    entries: [
+                        .run(Run(id: 1518, text: "I am answering it again.")),
+                        .properties(Properties(id: 431, title: "A Word About Wake Times")),
+                    ]
+                ),
+                Paragraph(
+                    entries: [
+                        .run(Run(id: 1519, text: "I am answering it again.")),
+                    ]
+                )
+            ]
+        )
+        XCTAssertEqual(result, expected)
+    }
+}

--- a/Tests/XMLCoderTests/NestingTests.swift
+++ b/Tests/XMLCoderTests/NestingTests.swift
@@ -73,8 +73,10 @@ final class NestingTests: XCTestCase {
             </element>
             """
         let encoded = xml.data(using: .utf8)!
+        let expected = [[1, 2, 3], [1, 2, 3]]
+        let decoded = try decoder.decode([[Int]].self, from: encoded)
 
-        XCTAssertNoThrow(try decoder.decode(type(of: unkeyedWithinUnkeyed), from: encoded))
+        XCTAssertEqual(expected, decoded)
     }
 
     func testDecodeUnkeyedWithinKeyed() throws {
@@ -90,8 +92,10 @@ final class NestingTests: XCTestCase {
             </element>
             """
         let encoded = xml.data(using: .utf8)!
+        let expected = ["first": [1, 2, 3], "second": [1, 2, 3]]
+        let decoded = try decoder.decode([String: [Int]].self, from: encoded)
 
-        XCTAssertNoThrow(try decoder.decode(type(of: unkeyedWithinKeyed), from: encoded))
+        XCTAssertEqual(expected, decoded)
     }
 
     func testDecodeKeyedWithinUnkeyed() throws {
@@ -107,8 +111,10 @@ final class NestingTests: XCTestCase {
             </element>
             """
         let encoded = xml.data(using: .utf8)!
+        let expected = [["first": 1], ["second": 2]]
+        let decoded = try decoder.decode([[String: Int]].self, from: encoded)
 
-        XCTAssertNoThrow(try decoder.decode(type(of: keyedWithinUnkeyed), from: encoded))
+        XCTAssertEqual(expected, decoded)
     }
 
     func testDecodeKeyedWithinKeyed() throws {
@@ -126,8 +132,10 @@ final class NestingTests: XCTestCase {
             </element>
             """
         let encoded = xml.data(using: .utf8)!
+        let expected = ["first": ["a": 1, "b": 2], "second": ["c": 3, "d": 4]]
+        let decoded = try decoder.decode([String: [String: Int]].self, from: encoded)
 
-        XCTAssertNoThrow(try decoder.decode(type(of: keyedWithinKeyed), from: encoded))
+        XCTAssertEqual(expected, decoded)
     }
 
     static var allTests = [

--- a/XMLCoder.xcodeproj/project.pbxproj
+++ b/XMLCoder.xcodeproj/project.pbxproj
@@ -21,6 +21,9 @@
 /* End PBXAggregateTarget section */
 
 /* Begin PBXBuildFile section */
+		14344A3522D540F400427D35 /* EnumAssociatedValueTestSimple.swift in Sources */ = {isa = PBXBuildFile; fileRef = 14344A3422D540F400427D35 /* EnumAssociatedValueTestSimple.swift */; };
+		14A8A49322D801A0006AFC91 /* NestedEnumAssociatedValueTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 14A8A49222D801A0006AFC91 /* NestedEnumAssociatedValueTest.swift */; };
+		14A8A49522D8FF49006AFC91 /* EnumAssociatedValueTestComposite.swift in Sources */ = {isa = PBXBuildFile; fileRef = 14A8A49422D8FF49006AFC91 /* EnumAssociatedValueTestComposite.swift */; };
 		A61DCCD821DF9CA200C0A19D /* ClassTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A61DCCD621DF8DB300C0A19D /* ClassTests.swift */; };
 		A61FE03921E4D60B0015D993 /* UnkeyedIntTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A61FE03721E4D4F10015D993 /* UnkeyedIntTests.swift */; };
 		A61FE03C21E4EAB10015D993 /* KeyedIntTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A61FE03A21E4EA8B0015D993 /* KeyedIntTests.swift */; };
@@ -143,6 +146,9 @@
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXFileReference section */
+		14344A3422D540F400427D35 /* EnumAssociatedValueTestSimple.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EnumAssociatedValueTestSimple.swift; sourceTree = "<group>"; };
+		14A8A49222D801A0006AFC91 /* NestedEnumAssociatedValueTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NestedEnumAssociatedValueTest.swift; sourceTree = "<group>"; };
+		14A8A49422D8FF49006AFC91 /* EnumAssociatedValueTestComposite.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EnumAssociatedValueTestComposite.swift; sourceTree = "<group>"; };
 		A61DCCD621DF8DB300C0A19D /* ClassTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ClassTests.swift; sourceTree = "<group>"; };
 		A61FE03721E4D4F10015D993 /* UnkeyedIntTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UnkeyedIntTests.swift; sourceTree = "<group>"; };
 		A61FE03A21E4EA8B0015D993 /* KeyedIntTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KeyedIntTests.swift; sourceTree = "<group>"; };
@@ -395,6 +401,9 @@
 				BF9457BD21CBB516005ACFDE /* Box */,
 				BF9457E121CBB6BC005ACFDE /* Minimal */,
 				D1AC9464224E3E1F004AB49B /* AttributedEnumIntrinsicTest.swift */,
+				14344A3422D540F400427D35 /* EnumAssociatedValueTestSimple.swift */,
+				14A8A49422D8FF49006AFC91 /* EnumAssociatedValueTestComposite.swift */,
+				14A8A49222D801A0006AFC91 /* NestedEnumAssociatedValueTest.swift */,
 				B3B6902D220A71DF0084D407 /* AttributedIntrinsicTest.swift */,
 				BF63EF1D21CEC99A001D38C5 /* BenchmarkTests.swift */,
 				OBJ_28 /* BooksTest.swift */,
@@ -655,6 +664,7 @@
 				BF9457F221CBB6BC005ACFDE /* UnkeyedTests.swift in Sources */,
 				A61FE03C21E4EAB10015D993 /* KeyedIntTests.swift in Sources */,
 				BF9457F321CBB6BC005ACFDE /* DateTests.swift in Sources */,
+				14A8A49322D801A0006AFC91 /* NestedEnumAssociatedValueTest.swift in Sources */,
 				D1D50D3122942EAE007098FC /* NestingTests.swift in Sources */,
 				BF9457D121CBB516005ACFDE /* UnkeyedBoxTests.swift in Sources */,
 				BF63EF6921D0FDB5001D38C5 /* XMLHeaderTests.swift in Sources */,
@@ -688,6 +698,7 @@
 				OBJ_85 /* NodeEncodingStrategyTests.swift in Sources */,
 				D1B6A2C22297EF6F005B8A6E /* BorderTest.swift in Sources */,
 				OBJ_86 /* NoteTest.swift in Sources */,
+				14A8A49522D8FF49006AFC91 /* EnumAssociatedValueTestComposite.swift in Sources */,
 				BF63EF0C21CD7F28001D38C5 /* EmptyTests.swift in Sources */,
 				B34B3C08220381AC00BCBA30 /* String+ExtensionsTests.swift in Sources */,
 				B3BE1D612202C1F600259831 /* DynamicNodeEncodingTest.swift in Sources */,
@@ -699,6 +710,7 @@
 				OBJ_88 /* PlantTest.swift in Sources */,
 				D1AC9466224E3E63004AB49B /* AttributedEnumIntrinsicTest.swift in Sources */,
 				BF63EF0821CD7AF8001D38C5 /* URLBoxTests.swift in Sources */,
+				14344A3522D540F400427D35 /* EnumAssociatedValueTestSimple.swift in Sources */,
 				BF9457DD21CBB62C005ACFDE /* DateBoxTests.swift in Sources */,
 				A61DCCD821DF9CA200C0A19D /* ClassTests.swift in Sources */,
 				BF9457CD21CBB516005ACFDE /* FloatBoxTests.swift in Sources */,

--- a/XMLCoder.xcodeproj/xcshareddata/xcbaselines/XMLCoder::XMLCoderTests.xcbaseline/6992DA37-E913-45F1-8DB7-5EC71BF0DA02.plist
+++ b/XMLCoder.xcodeproj/xcshareddata/xcbaselines/XMLCoder::XMLCoderTests.xcbaseline/6992DA37-E913-45F1-8DB7-5EC71BF0DA02.plist
@@ -1,0 +1,232 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>classNames</key>
+	<dict>
+		<key>BenchmarkTests</key>
+		<dict>
+			<key>testDecodeArrays()</key>
+			<dict>
+				<key>com.apple.XCTPerformanceMetric_WallClockTime</key>
+				<dict>
+					<key>baselineAverage</key>
+					<real>0.648</real>
+					<key>baselineIntegrationDisplayName</key>
+					<string>Local Baseline</string>
+				</dict>
+			</dict>
+			<key>testDecodeBools()</key>
+			<dict>
+				<key>com.apple.XCTPerformanceMetric_WallClockTime</key>
+				<dict>
+					<key>baselineAverage</key>
+					<real>0.0524</real>
+					<key>baselineIntegrationDisplayName</key>
+					<string>Local Baseline</string>
+				</dict>
+			</dict>
+			<key>testDecodeDatas()</key>
+			<dict>
+				<key>com.apple.XCTPerformanceMetric_WallClockTime</key>
+				<dict>
+					<key>baselineAverage</key>
+					<real>0.0608</real>
+					<key>baselineIntegrationDisplayName</key>
+					<string>Local Baseline</string>
+				</dict>
+			</dict>
+			<key>testDecodeDates()</key>
+			<dict>
+				<key>com.apple.XCTPerformanceMetric_WallClockTime</key>
+				<dict>
+					<key>baselineAverage</key>
+					<real>0.0797</real>
+					<key>baselineIntegrationDisplayName</key>
+					<string>Local Baseline</string>
+				</dict>
+			</dict>
+			<key>testDecodeDecimals()</key>
+			<dict>
+				<key>com.apple.XCTPerformanceMetric_WallClockTime</key>
+				<dict>
+					<key>baselineAverage</key>
+					<real>0.0906</real>
+					<key>baselineIntegrationDisplayName</key>
+					<string>Local Baseline</string>
+				</dict>
+			</dict>
+			<key>testDecodeDictionaries()</key>
+			<dict>
+				<key>com.apple.XCTPerformanceMetric_WallClockTime</key>
+				<dict>
+					<key>baselineAverage</key>
+					<real>0.261</real>
+					<key>baselineIntegrationDisplayName</key>
+					<string>Local Baseline</string>
+				</dict>
+			</dict>
+			<key>testDecodeFloats()</key>
+			<dict>
+				<key>com.apple.XCTPerformanceMetric_WallClockTime</key>
+				<dict>
+					<key>baselineAverage</key>
+					<real>0.0555</real>
+					<key>baselineIntegrationDisplayName</key>
+					<string>Local Baseline</string>
+				</dict>
+			</dict>
+			<key>testDecodeInts()</key>
+			<dict>
+				<key>com.apple.XCTPerformanceMetric_WallClockTime</key>
+				<dict>
+					<key>baselineAverage</key>
+					<real>0.0587</real>
+					<key>baselineIntegrationDisplayName</key>
+					<string>Local Baseline</string>
+				</dict>
+			</dict>
+			<key>testDecodeNulls()</key>
+			<dict>
+				<key>com.apple.XCTPerformanceMetric_WallClockTime</key>
+				<dict>
+					<key>baselineAverage</key>
+					<real>0.0446</real>
+					<key>baselineIntegrationDisplayName</key>
+					<string>Local Baseline</string>
+				</dict>
+			</dict>
+			<key>testDecodeUInts()</key>
+			<dict>
+				<key>com.apple.XCTPerformanceMetric_WallClockTime</key>
+				<dict>
+					<key>baselineAverage</key>
+					<real>0.0509</real>
+					<key>baselineIntegrationDisplayName</key>
+					<string>Local Baseline</string>
+				</dict>
+			</dict>
+			<key>testDecodeURLs()</key>
+			<dict>
+				<key>com.apple.XCTPerformanceMetric_WallClockTime</key>
+				<dict>
+					<key>baselineAverage</key>
+					<real>0.0575</real>
+					<key>baselineIntegrationDisplayName</key>
+					<string>Local Baseline</string>
+				</dict>
+			</dict>
+			<key>testEncodeArrays()</key>
+			<dict>
+				<key>com.apple.XCTPerformanceMetric_WallClockTime</key>
+				<dict>
+					<key>baselineAverage</key>
+					<real>0.103</real>
+					<key>baselineIntegrationDisplayName</key>
+					<string>Local Baseline</string>
+				</dict>
+			</dict>
+			<key>testEncodeBools()</key>
+			<dict>
+				<key>com.apple.XCTPerformanceMetric_WallClockTime</key>
+				<dict>
+					<key>baselineAverage</key>
+					<real>0.0204</real>
+					<key>baselineIntegrationDisplayName</key>
+					<string>Local Baseline</string>
+				</dict>
+			</dict>
+			<key>testEncodeDatas()</key>
+			<dict>
+				<key>com.apple.XCTPerformanceMetric_WallClockTime</key>
+				<dict>
+					<key>baselineAverage</key>
+					<real>0.0234</real>
+					<key>baselineIntegrationDisplayName</key>
+					<string>Local Baseline</string>
+				</dict>
+			</dict>
+			<key>testEncodeDates()</key>
+			<dict>
+				<key>com.apple.XCTPerformanceMetric_WallClockTime</key>
+				<dict>
+					<key>baselineAverage</key>
+					<real>0.0244</real>
+					<key>baselineIntegrationDisplayName</key>
+					<string>Local Baseline</string>
+				</dict>
+			</dict>
+			<key>testEncodeDecimals()</key>
+			<dict>
+				<key>com.apple.XCTPerformanceMetric_WallClockTime</key>
+				<dict>
+					<key>baselineAverage</key>
+					<real>0.0194</real>
+					<key>baselineIntegrationDisplayName</key>
+					<string>Local Baseline</string>
+				</dict>
+			</dict>
+			<key>testEncodeDictionaries()</key>
+			<dict>
+				<key>com.apple.XCTPerformanceMetric_WallClockTime</key>
+				<dict>
+					<key>baselineAverage</key>
+					<real>0.136</real>
+					<key>baselineIntegrationDisplayName</key>
+					<string>Local Baseline</string>
+				</dict>
+			</dict>
+			<key>testEncodeFloats()</key>
+			<dict>
+				<key>com.apple.XCTPerformanceMetric_WallClockTime</key>
+				<dict>
+					<key>baselineAverage</key>
+					<real>0.022</real>
+					<key>baselineIntegrationDisplayName</key>
+					<string>Local Baseline</string>
+				</dict>
+			</dict>
+			<key>testEncodeInts()</key>
+			<dict>
+				<key>com.apple.XCTPerformanceMetric_WallClockTime</key>
+				<dict>
+					<key>baselineAverage</key>
+					<real>0.021</real>
+					<key>baselineIntegrationDisplayName</key>
+					<string>Local Baseline</string>
+				</dict>
+			</dict>
+			<key>testEncodeNulls()</key>
+			<dict>
+				<key>com.apple.XCTPerformanceMetric_WallClockTime</key>
+				<dict>
+					<key>baselineAverage</key>
+					<real>0.00882</real>
+					<key>baselineIntegrationDisplayName</key>
+					<string>Local Baseline</string>
+				</dict>
+			</dict>
+			<key>testEncodeUInts()</key>
+			<dict>
+				<key>com.apple.XCTPerformanceMetric_WallClockTime</key>
+				<dict>
+					<key>baselineAverage</key>
+					<real>0.0232</real>
+					<key>baselineIntegrationDisplayName</key>
+					<string>Local Baseline</string>
+				</dict>
+			</dict>
+			<key>testEncodeURLs()</key>
+			<dict>
+				<key>com.apple.XCTPerformanceMetric_WallClockTime</key>
+				<dict>
+					<key>baselineAverage</key>
+					<real>0.0237</real>
+					<key>baselineIntegrationDisplayName</key>
+					<string>Local Baseline</string>
+				</dict>
+			</dict>
+		</dict>
+	</dict>
+</dict>
+</plist>

--- a/XMLCoder.xcodeproj/xcshareddata/xcbaselines/XMLCoder::XMLCoderTests.xcbaseline/Info.plist
+++ b/XMLCoder.xcodeproj/xcshareddata/xcbaselines/XMLCoder::XMLCoderTests.xcbaseline/Info.plist
@@ -4,6 +4,30 @@
 <dict>
 	<key>runDestinationsByUUID</key>
 	<dict>
+		<key>6992DA37-E913-45F1-8DB7-5EC71BF0DA02</key>
+		<dict>
+			<key>localComputer</key>
+			<dict>
+				<key>busSpeedInMHz</key>
+				<integer>100</integer>
+				<key>cpuCount</key>
+				<integer>1</integer>
+				<key>cpuKind</key>
+				<string>Intel Core i5</string>
+				<key>cpuSpeedInMHz</key>
+				<integer>2400</integer>
+				<key>logicalCPUCoresPerPackage</key>
+				<integer>4</integer>
+				<key>modelCode</key>
+				<string>MacBookPro11,1</string>
+				<key>physicalCPUCoresPerPackage</key>
+				<integer>2</integer>
+				<key>platformIdentifier</key>
+				<string>com.apple.platform.macosx</string>
+			</dict>
+			<key>targetArchitecture</key>
+			<string>x86_64</string>
+		</dict>
 		<key>76E090BF-7AFE-4988-A06A-3C423396A4A4</key>
 		<dict>
 			<key>localComputer</key>


### PR DESCRIPTION
This PR is an initial step towards adding support for Decoding union-type–like enums-with-associated-values (as presented in #25 and #91). 

There is a single regression test which is currently failing (`NestingTests.testDecodeUnkeyedWithinUnkeyed()`), though it doesn't seem out of reach to fix it.

I have added test cases for both #25 and #91, which are passing. For the case of #91, I haven't had success decoding the empty `Break` type.

The changes here seem both a bit magical as well as grotesque, but it seems like it is at a good place to stop and talk about further directions!

There are three changes made to the source here: 

- In `XMLCoderElement.transformToBoxTree()`, a special case is made to prevent enums-with-associated-value–like types getting represented as attributed unkeyed values.
- In `XMLDecoderImplementation.unkeyedContainer()`, keyed boxes get transformed into unkeyed boxes wherein each key-value pair from the original is packaged up into its own `KeyedBox` carrying a single element representing the key and value. This allows the key to be retrievable downstream in the `XMLUnkeyedDecodingContainer`.
- In `XMLUnkeyedDecodingContainer.decode(...)`, the container packaged up by `XMLDecoderImplementation.unkeyedContainer()` gets unpackaged in the case it may hold the contents of an enum-with-associated-value.