### PR TITLE
Fix typo: errorContextLenght -> errorContextLength

### DIFF
--- a/Sources/XMLCoder/Decoder/XMLDecoderImplementation.swift
+++ b/Sources/XMLCoder/Decoder/XMLDecoderImplementation.swift
@@ -27,8 +27,8 @@ class XMLDecoderImplementation: Decoder {
         return options.userInfo
     }
 
-    // The error context lenght
-    open var errorContextLenght: UInt = 0
+    // The error context length
+    open var errorContextLength: UInt = 0
 
     // MARK: - Initialization
 


### PR DESCRIPTION
This is just a typo fix but it _is_ public API.