### PR TITLE
Fix Decoding of Nested Arrays of Enums

### DIFF
--- a/Sources/XMLCoder/Decoder/XMLKeyedDecodingContainer.swift
+++ b/Sources/XMLCoder/Decoder/XMLKeyedDecodingContainer.swift
@@ -162,10 +162,10 @@ struct XMLKeyedDecodingContainer<K: CodingKey>: KeyedDecodingContainerProtocol {
 
         let elements = container.unboxed.elements[key.stringValue]
 
-        if let containsKeyed = elements as? [KeyedBox], !containsKeyed.isEmpty {
+        if let containsKeyed = elements as? [KeyedBox], let keyed = containsKeyed.first {
             return XMLUnkeyedDecodingContainer(
                 referencing: decoder,
-                wrapping: SharedBox(containsKeyed.first!.elements.map(SingleKeyedBox.init))
+                wrapping: SharedBox(keyed.elements.map(SingleKeyedBox.init))
             )
         } else {
             return XMLUnkeyedDecodingContainer(

--- a/Sources/XMLCoder/Decoder/XMLKeyedDecodingContainer.swift
+++ b/Sources/XMLCoder/Decoder/XMLKeyedDecodingContainer.swift
@@ -160,19 +160,14 @@ struct XMLKeyedDecodingContainer<K: CodingKey>: KeyedDecodingContainerProtocol {
         decoder.codingPath.append(key)
         defer { decoder.codingPath.removeLast() }
 
-        let elements = container.unboxed.elements[key.stringValue]
-
-        if let containsKeyed = elements as? [KeyedBox], let keyed = containsKeyed.first {
-            return XMLUnkeyedDecodingContainer(
-                referencing: decoder,
-                wrapping: SharedBox(keyed.elements.map(SingleKeyedBox.init))
-            )
-        } else {
-            return XMLUnkeyedDecodingContainer(
-                referencing: decoder,
-                wrapping: SharedBox(elements)
-            )
+        let elements = container.withShared { keyedBox in
+            keyedBox.elements[key.stringValue]
         }
+
+        return XMLUnkeyedDecodingContainer(
+            referencing: decoder,
+            wrapping: SharedBox(elements)
+        )
     }
 
     public func superDecoder() throws -> Decoder {

--- a/Tests/XMLCoderTests/NestedChoiceArrayTest.swift
+++ b/Tests/XMLCoderTests/NestedChoiceArrayTest.swift
@@ -1,0 +1,116 @@
+//
+//  NestedChoiceArrayTest.swift
+//  XMLCoder
+//
+//  Created by Benjamin Wetherfield on 8/22/19.
+//
+
+import XCTest
+@testable import XMLCoder
+
+private struct Book: Decodable {
+    let title: String
+    let chapters: [Chapter]
+
+    enum CodingKeys: String, CodingKey {
+        case title
+        case chapters
+    }
+
+    init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        title = try container.decode(String.self, forKey: .title)
+
+        var chapters = [Chapter]()
+
+        if var chapterContainer = try? container.nestedUnkeyedContainer(forKey: .chapters) {
+            while !chapterContainer.isAtEnd {
+                chapters.append(try chapterContainer.decode(Chapter.self))
+            }
+        }
+
+        self.chapters = chapters
+    }
+
+    init(title: String, chapters: [Chapter]) {
+        self.title = title
+        self.chapters = chapters
+    }
+}
+
+private enum Chapter {
+    struct Content {
+        let title: String
+        let content: String
+    }
+
+    case intro(Content)
+    case body(Content)
+    case outro(Content)
+}
+
+private enum BookError: Error {
+    case unknownChapterType
+}
+
+extension Chapter: Decodable {
+    enum CodingKeys: String, XMLChoiceCodingKey {
+        case intro, body = "chapter", outro
+    }
+
+    init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        do {
+            self = .body(try container.decode(Content.self, forKey: .body))
+        } catch {
+            do {
+                self = .intro(try container.decode(Content.self, forKey: .intro))
+            } catch {
+                self = .outro(try container.decode(Content.self, forKey: .outro))
+            }
+        }
+    }
+}
+
+extension Chapter.Content: Decodable {
+    enum CodingKeys: String, CodingKey {
+        case title
+        case value = ""
+    }
+
+    init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+
+        title = try container.decode(String.self, forKey: .title)
+        content = try container.decode(String.self, forKey: .value)
+    }
+}
+
+extension Book: Equatable {}
+extension Chapter: Equatable {}
+extension Chapter.Content: Equatable {}
+
+class NestedChoiceArrayTest: XCTestCase {
+    func testDecodingNestedChoiceArray() throws {
+        let xml = """
+        <?xml version="1.0" encoding="UTF-8"?>
+        <book title="Example">
+            <chapters>
+                <intro title="Intro">Content of first chapter</intro>
+                <chapter title="Chapter 1">Content of chapter 1</chapter>
+                <chapter title="Chapter 2">Content of chapter 2</chapter>
+                <outro title="Epilogue">Content of last chapter</outro>
+            </chapters>
+        </book>
+        """
+        let decoded = try XMLDecoder().decode(Book.self, from: xml.data(using: .utf8)!)
+        let expected = Book(title: "Example",
+                            chapters: [
+                                .intro(.init(title: "Intro", content: "Content of first chapter")),
+                                .body(.init(title: "Chapter 1", content: "Content of chapter 1")),
+                                .body(.init(title: "Chapter 2", content: "Content of chapter 2")),
+                                .outro(.init(title: "Epilogue", content: "Content of last chapter")),
+                            ])
+        XCTAssertEqual(decoded, expected)
+    }
+}

--- a/XMLCoder.xcodeproj/project.pbxproj
+++ b/XMLCoder.xcodeproj/project.pbxproj
@@ -21,6 +21,7 @@
 /* End PBXAggregateTarget section */
 
 /* Begin PBXBuildFile section */
+		B5EA3BB6230F237800D8D69B /* NestedChoiceArrayTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = B5EA3BB4230F235C00D8D69B /* NestedChoiceArrayTest.swift */; };
 		OBJ_148 /* BoolBox.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_12 /* BoolBox.swift */; };
 		OBJ_149 /* Box.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_13 /* Box.swift */; };
 		OBJ_150 /* ChoiceBox.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_14 /* ChoiceBox.swift */; };
@@ -152,6 +153,7 @@
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXFileReference section */
+		B5EA3BB4230F235C00D8D69B /* NestedChoiceArrayTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NestedChoiceArrayTest.swift; sourceTree = "<group>"; };
 		OBJ_100 /* DecimalTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DecimalTests.swift; sourceTree = "<group>"; };
 		OBJ_101 /* EmptyTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EmptyTests.swift; sourceTree = "<group>"; };
 		OBJ_102 /* FloatTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FloatTests.swift; sourceTree = "<group>"; };
@@ -446,6 +448,7 @@
 				OBJ_125 /* SimpleChoiceTests.swift */,
 				OBJ_126 /* SingleChildTests.swift */,
 				OBJ_127 /* SpacePreserveTest.swift */,
+				B5EA3BB4230F235C00D8D69B /* NestedChoiceArrayTest.swift */,
 			);
 			name = XMLCoderTests;
 			path = Tests/XMLCoderTests;
@@ -717,6 +720,7 @@
 				OBJ_252 /* NullTests.swift in Sources */,
 				OBJ_253 /* OptionalTests.swift in Sources */,
 				OBJ_254 /* StringTests.swift in Sources */,
+				B5EA3BB6230F237800D8D69B /* NestedChoiceArrayTest.swift in Sources */,
 				OBJ_255 /* UIntTests.swift in Sources */,
 				OBJ_256 /* URLTests.swift in Sources */,
 				OBJ_257 /* UnkeyedIntTests.swift in Sources */,

--- a/XMLCoder.xcodeproj/xcshareddata/xcbaselines/XMLCoder::XMLCoderTests.xcbaseline/76E090BF-7AFE-4988-A06A-3C423396A4A4.plist
+++ b/XMLCoder.xcodeproj/xcshareddata/xcbaselines/XMLCoder::XMLCoderTests.xcbaseline/76E090BF-7AFE-4988-A06A-3C423396A4A4.plist
@@ -61,7 +61,7 @@
 				<key>com.apple.XCTPerformanceMetric_WallClockTime</key>
 				<dict>
 					<key>baselineAverage</key>
-					<real>0.08847</real>
+					<real>0.263</real>
 					<key>baselineIntegrationDisplayName</key>
 					<string>Local Baseline</string>
 				</dict>


### PR DESCRIPTION
I believe the structure in issue #122 provides the right use case for a `nestedUnkeyedContainer` (for key `Chapters`). As such I add a test case with the full proposed usage and a fix for `XMLKeyedDecodingContainer.nestedUnkeyedContainer` on the implementation side that allows the decoding of wrapped arrays of `enum` types.

The key lines on the user-side are within the `Decodable` implementation for `Book`, with decoding initializer using nesting syntax as follows:
```swift
extension Book: Decodable {
    enum CodingKeys: String, CodingKey {
        case title
        case chapters
    }

    init(from decoder: Decoder) throws {
        let container = try decoder.container(keyedBy: CodingKeys.self)
        title = try container.decode(String.self, forKey: .title)

        var chapters = [Chapter]()

        if var chapterContainer = try? container.nestedUnkeyedContainer(forKey: .chapters) {
            while !chapterContainer.isAtEnd {
                chapters.append(try chapterContainer.decode(Chapter.self))
            }
        }

        self.chapters = chapters
    }
}
```
`Book` is defined as follows, wrapping an array of the `enum` type `Chapter`.
```swift
struct Book: Decodable {
    let title: String
    let chapters: [Chapter]

    init(title: String, chapters: [Chapter]) {
        self.title = title
        self.chapters = chapters
    }
}
```
More info on how the `enum` type gets decoded from XML choice elements can be found in #119.