### PR TITLE
Conditionally conform to Combine.TopLevelDecoder

### DIFF
--- a/README.md
+++ b/README.md
@@ -269,6 +269,25 @@ extension IntOrString: Codable {
 This is described in more details in PR [\#119](https://github.com/MaxDesiatov/XMLCoder/pull/119) 
 by [@jsbean](https://github.com/jsbean) and [@bwetherfield](https://github.com/bwetherfield).
 
+## Integrating with [Combine](https://developer.apple.com/documentation/combine)
+
+When Apple's Combine framework is available, `XMLDecoder` conforms to the
+`TopLevelDecoder` protocol, which allows it to be used with the
+`decode(type:decoder:)` operator:
+
+```swift
+import Combine
+import Foundation
+import XMLCoder
+
+func fetchBook(from url: URL) -> AnyPublisher<Book, Error> {
+    return URLSession.shared.dataTaskPublisher(for: url)
+        .map(\.data)
+        .decode(type: Book.self, decoder: XMLDecoder())
+        .eraseToAnyPublisher()
+}
+```
+
 ## Installation
 
 ### Requirements

--- a/Sources/XMLCoder/Decoder/XMLDecoder.swift
+++ b/Sources/XMLCoder/Decoder/XMLDecoder.swift
@@ -368,3 +368,11 @@ open class XMLDecoder {
         return try decoder.unbox(topLevel)
     }
 }
+
+// MARK: TopLevelDecoder
+
+#if canImport(Combine)
+import protocol Combine.TopLevelDecoder
+
+extension XMLDecoder: TopLevelDecoder {}
+#endif

--- a/Tests/XMLCoderTests/CombineTests.swift
+++ b/Tests/XMLCoderTests/CombineTests.swift
@@ -1,0 +1,37 @@
+//
+//  CombineTests.swift
+//  XMLCoder
+//
+//  Created by Adam Sharp on 9/29/19.
+//
+
+#if canImport(Combine)
+import Combine
+import Foundation
+import XCTest
+import XMLCoder
+
+private let xml = """
+<?xml version="1.0" encoding="UTF-8"?>
+<foo>
+    <name>Foo</name>
+</foo>
+""".data(using: .utf8)!
+
+private struct Foo: Decodable {
+    var name: String
+}
+
+@available(iOS 13.0, macOS 10.15.0, macCatalyst 13.0, tvOS 13.0, watchOS 6.0, *)
+class CombineTests: XCTestCase {
+    func testDecodeFromXMLDecoder() {
+        let data = Just(xml)
+        var foo: Foo?
+        _ = data.decode(type: Foo.self, decoder: XMLDecoder()).sink(
+            receiveCompletion: { _ in },
+            receiveValue: { foo = $0 }
+        )
+        XCTAssertEqual(foo?.name, "Foo")
+    }
+}
+#endif

--- a/Tests/XMLCoderTests/CombineTests.swift
+++ b/Tests/XMLCoderTests/CombineTests.swift
@@ -5,7 +5,7 @@
 //  Created by Adam Sharp on 9/29/19.
 //
 
-#if canImport(Combine)
+#if canImport(Combine) && !os(macOS)
 import Combine
 import Foundation
 import XCTest

--- a/Tests/XMLCoderTests/CombineTests.swift
+++ b/Tests/XMLCoderTests/CombineTests.swift
@@ -22,7 +22,7 @@ private struct Foo: Decodable {
     var name: String
 }
 
-@available(iOS 13.0, macOS 10.15.0, macCatalyst 13.0, tvOS 13.0, watchOS 6.0, *)
+@available(iOS 13.0, macOS 10.15.0, tvOS 13.0, watchOS 6.0, *)
 class CombineTests: XCTestCase {
     func testDecodeFromXMLDecoder() {
         let data = Just(xml)

--- a/XMLCoder.xcodeproj/project.pbxproj
+++ b/XMLCoder.xcodeproj/project.pbxproj
@@ -21,6 +21,7 @@
 /* End PBXAggregateTarget section */
 
 /* Begin PBXBuildFile section */
+		4A062D4F2341924E009BCAC1 /* CombineTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4A062D4E2341924E009BCAC1 /* CombineTests.swift */; };
 		OBJ_148 /* BoolBox.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_12 /* BoolBox.swift */; };
 		OBJ_149 /* Box.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_13 /* Box.swift */; };
 		OBJ_150 /* ChoiceBox.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_14 /* ChoiceBox.swift */; };
@@ -152,6 +153,7 @@
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXFileReference section */
+		4A062D4E2341924E009BCAC1 /* CombineTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CombineTests.swift; sourceTree = "<group>"; };
 		OBJ_100 /* DecimalTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DecimalTests.swift; sourceTree = "<group>"; };
 		OBJ_101 /* EmptyTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EmptyTests.swift; sourceTree = "<group>"; };
 		OBJ_102 /* FloatTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FloatTests.swift; sourceTree = "<group>"; };
@@ -424,6 +426,7 @@
 				OBJ_86 /* CDCatalog.swift */,
 				OBJ_87 /* CDTest.swift */,
 				OBJ_88 /* ClassTests.swift */,
+				4A062D4E2341924E009BCAC1 /* CombineTests.swift */,
 				OBJ_89 /* CompositeChoiceTests.swift */,
 				OBJ_90 /* DecodingContainerTests.swift */,
 				OBJ_91 /* DynamicNodeDecodingTest.swift */,
@@ -734,6 +737,7 @@
 				OBJ_269 /* RJITest.swift in Sources */,
 				OBJ_270 /* RelationshipsTest.swift in Sources */,
 				OBJ_271 /* SimpleChoiceTests.swift in Sources */,
+				4A062D4F2341924E009BCAC1 /* CombineTests.swift in Sources */,
 				OBJ_272 /* SingleChildTests.swift in Sources */,
 				OBJ_273 /* SpacePreserveTest.swift in Sources */,
 			);


### PR DESCRIPTION
This enables use of `XMLDecoder` with Combine's `decode(_:decoder:)` operator by conditionally conforming to `TopLevelDecoder` when Combine is available.

I explored doing the same for `TopLevelEncoder`, but `XMLEncoder` currently requires `rootKey:` to be specified at encoding time, so it's not possible to provide an implementation of `encode(_:)` without some design around how to dynamically determine the root key to use.