### PR TITLE
Root Level Attribute Encoding

### DIFF
--- a/Tests/XMLCoderTests/RootLevelAttributeTest.swift
+++ b/Tests/XMLCoderTests/RootLevelAttributeTest.swift
@@ -33,11 +33,11 @@ let expected = """
 """
 
 class RootLevelAttributeTest: XCTestCase {
-    func testPolicyEncodingAtRoot() {
+    func testPolicyEncodingAtRoot() throws {
         let encoder = XMLEncoder()
         encoder.outputFormatting = [.prettyPrinted]
         let policy = Policy(name: "generic", initial: "more xml here")
-        let data = try! encoder.encode(policy,
+        let data = try encoder.encode(policy,
                                        withRootKey: "policy",
                                        header: XMLHeader(version: 1.0, encoding: "UTF-8"))
         XCTAssertEqual(String(data: data, encoding: .utf8)!, expected)

--- a/Tests/XMLCoderTests/RootLevelAttributeTest.swift
+++ b/Tests/XMLCoderTests/RootLevelAttributeTest.swift
@@ -38,8 +38,8 @@ class RootLevelAttributeTest: XCTestCase {
         encoder.outputFormatting = [.prettyPrinted]
         let policy = Policy(name: "generic", initial: "more xml here")
         let data = try encoder.encode(policy,
-                                       withRootKey: "policy",
-                                       header: XMLHeader(version: 1.0, encoding: "UTF-8"))
+                                      withRootKey: "policy",
+                                      header: XMLHeader(version: 1.0, encoding: "UTF-8"))
         XCTAssertEqual(String(data: data, encoding: .utf8)!, expected)
     }
 }

--- a/Tests/XMLCoderTests/RootLevelAttributeTest.swift
+++ b/Tests/XMLCoderTests/RootLevelAttributeTest.swift
@@ -1,0 +1,45 @@
+//
+//  RootLevelAttributeTest.swift
+//  XMLCoderTests
+//
+//  Created by Benjamin Wetherfield on 9/28/19.
+//
+
+import Foundation
+import XCTest
+@testable import XMLCoder
+
+private struct Policy: Encodable, DynamicNodeEncoding {
+    var name: String
+    var initial: String
+
+    enum CodingKeys: String, CodingKey {
+        case name, initial
+    }
+
+    public static func nodeEncoding(for key: CodingKey) -> XMLEncoder.NodeEncoding {
+        switch key {
+        case Policy.CodingKeys.name: return .attribute
+        default: return .element
+        }
+    }
+}
+
+let expected = """
+<?xml version="1.0" encoding="UTF-8"?>
+<policy name="generic">
+    <initial>more xml here</initial>
+</policy>
+"""
+
+class RootLevelAttributeTest: XCTestCase {
+    func testPolicyEncodingAtRoot() {
+        let encoder = XMLEncoder()
+        encoder.outputFormatting = [.prettyPrinted]
+        let policy = Policy(name: "generic", initial: "more xml here")
+        let data = try! encoder.encode(policy,
+                                       withRootKey: "policy",
+                                       header: XMLHeader(version: 1.0, encoding: "UTF-8"))
+        XCTAssertEqual(String(data: data, encoding: .utf8)!, expected)
+    }
+}

--- a/XMLCoder.xcodeproj/project.pbxproj
+++ b/XMLCoder.xcodeproj/project.pbxproj
@@ -21,6 +21,7 @@
 /* End PBXAggregateTarget section */
 
 /* Begin PBXBuildFile section */
+		B5F74472233F74E400BBDB15 /* RootLevelAttributeTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = B5F74471233F74E400BBDB15 /* RootLevelAttributeTest.swift */; };
 		OBJ_148 /* BoolBox.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_12 /* BoolBox.swift */; };
 		OBJ_149 /* Box.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_13 /* Box.swift */; };
 		OBJ_150 /* ChoiceBox.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_14 /* ChoiceBox.swift */; };
@@ -152,6 +153,7 @@
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXFileReference section */
+		B5F74471233F74E400BBDB15 /* RootLevelAttributeTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RootLevelAttributeTest.swift; sourceTree = "<group>"; };
 		OBJ_100 /* DecimalTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DecimalTests.swift; sourceTree = "<group>"; };
 		OBJ_101 /* EmptyTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EmptyTests.swift; sourceTree = "<group>"; };
 		OBJ_102 /* FloatTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FloatTests.swift; sourceTree = "<group>"; };
@@ -446,6 +448,7 @@
 				OBJ_125 /* SimpleChoiceTests.swift */,
 				OBJ_126 /* SingleChildTests.swift */,
 				OBJ_127 /* SpacePreserveTest.swift */,
+				B5F74471233F74E400BBDB15 /* RootLevelAttributeTest.swift */,
 			);
 			name = XMLCoderTests;
 			path = Tests/XMLCoderTests;
@@ -706,6 +709,7 @@
 				OBJ_241 /* KeyDecodingAndEncodingStrategyTests.swift in Sources */,
 				OBJ_242 /* BoolTests.swift in Sources */,
 				OBJ_243 /* BoxTreeTests.swift in Sources */,
+				B5F74472233F74E400BBDB15 /* RootLevelAttributeTest.swift in Sources */,
 				OBJ_244 /* DataTests.swift in Sources */,
 				OBJ_245 /* DateTests.swift in Sources */,
 				OBJ_246 /* DecimalTests.swift in Sources */,


### PR DESCRIPTION
Resolves #127. I think the plist encoding/decoding should be independent of the XML encoding phase. I have tried to reproduce just the relevant encoding phase and it seems to work.