### PR TITLE
Fix CocoaPods issue on Azure Pipelines

### DIFF
--- a/pod.sh
+++ b/pod.sh
@@ -3,5 +3,7 @@
 set -e 
 set -o pipefail
 
-pod repo update
+sudo gem uninstall cocoapods
+sudo gem install cocoapods -v 1.7.5
+pod setup
 pod lib lint --verbose


### PR DESCRIPTION
The issue is not reproducible with CocoaPods 1.7.5. The workaround can be removed when CocoaPods 1.8.4 is released and this or later version is available on Azure Pipelines.