### PR TITLE
Replace value intrinsic with empty string key

### DIFF
--- a/Sources/XMLCoder/Auxiliaries/Box/KeyedBox.swift
+++ b/Sources/XMLCoder/Auxiliaries/Box/KeyedBox.swift
@@ -24,7 +24,7 @@ struct KeyedBox {
     }
 
     var value: SimpleBox? {
-        return elements["value"].first as? SimpleBox
+        return elements[""].first as? SimpleBox
     }
 }
 

--- a/Sources/XMLCoder/Auxiliaries/XMLCoderElement.swift
+++ b/Sources/XMLCoder/Auxiliaries/XMLCoderElement.swift
@@ -61,7 +61,7 @@ struct XMLCoderElement: Equatable {
         // Handle attributed unkeyed value <foo attr="bar">zap</foo>
         // Value should be zap. Detect only when no other elements exist
         if elements.isEmpty, let value = value {
-            elements.append(StringBox(value), at: "value")
+            elements.append(StringBox(value), at: "")
         }
         return KeyedBox(elements: elements, attributes: attributes)
     }

--- a/Sources/XMLCoder/Decoder/XMLDecoderImplementation.swift
+++ b/Sources/XMLCoder/Decoder/XMLDecoderImplementation.swift
@@ -97,7 +97,7 @@ class XMLDecoderImplementation: Decoder {
             return KeyedDecodingContainer(XMLKeyedDecodingContainer<Key>(
                 referencing: self,
                 wrapping: SharedBox(KeyedBox(
-                    elements: KeyedStorage([("value", string)]),
+                    elements: KeyedStorage([("", string)]),
                     attributes: KeyedStorage()
                 ))
             ))

--- a/Sources/XMLCoder/Decoder/XMLKeyedDecodingContainer.swift
+++ b/Sources/XMLCoder/Decoder/XMLKeyedDecodingContainer.swift
@@ -232,29 +232,11 @@ extension XMLKeyedDecodingContainer {
 
         let elements = container
             .withShared { keyedBox -> [KeyedBox.Element] in
-                if ["value", ""].contains(key.stringValue) {
-                    let keyString = key.stringValue.isEmpty ? "value" : key.stringValue
-                    let value = keyedBox.elements[keyString]
-                    if !value.isEmpty {
-                        return value.map {
-                            if let singleKeyed = $0 as? SingleKeyedBox {
-                                return singleKeyed.element
-                            } else {
-                                return $0
-                            }
-                        }
-                    } else if let value = keyedBox.value {
-                        return [value]
+                keyedBox.elements[key.stringValue].map {
+                    if let singleKeyed = $0 as? SingleKeyedBox {
+                        return singleKeyed.element
                     } else {
-                        return []
-                    }
-                } else {
-                    return keyedBox.elements[key.stringValue].map {
-                        if let singleKeyed = $0 as? SingleKeyedBox {
-                            return singleKeyed.element
-                        } else {
-                            return $0
-                        }
+                        return $0
                     }
                 }
             }

--- a/Tests/XMLCoderTests/AttributedIntrinsicTest.swift
+++ b/Tests/XMLCoderTests/AttributedIntrinsicTest.swift
@@ -82,7 +82,7 @@ private struct Foo: Codable, DynamicNodeEncoding, Equatable {
 
     enum CodingKeys: String, CodingKey {
         case id
-        case value
+        case value = ""
     }
 
     static func nodeEncoding(for key: CodingKey) -> XMLEncoder.NodeEncoding {
@@ -97,6 +97,10 @@ private struct Foo: Codable, DynamicNodeEncoding, Equatable {
 
 private struct FooValue: Codable, Equatable {
     let value: Int
+
+    enum CodingKeys: String, CodingKey {
+        case value = ""
+    }
 }
 
 private struct FooOptional: Codable, DynamicNodeEncoding, Equatable {
@@ -105,7 +109,7 @@ private struct FooOptional: Codable, DynamicNodeEncoding, Equatable {
 
     enum CodingKeys: String, CodingKey {
         case id
-        case value
+        case value = ""
     }
 
     static func nodeEncoding(for key: CodingKey) -> XMLEncoder.NodeEncoding {
@@ -167,7 +171,7 @@ private struct PreviewImageTime: Codable, Equatable, DynamicNodeEncoding {
 
     enum CodingKeys: String, CodingKey {
         case format
-        case value
+        case value = ""
     }
 
     static func nodeEncoding(for key: CodingKey) -> XMLEncoder.NodeEncoding {


### PR DESCRIPTION
## Overview
Restricts the special case usage of `"value"` OR `""` as a coding key, as implemented in #73 to just `""`. `"value"` resumes functioning as a normal coding key. 

## Example
As noted in #145, `"value"` is starting to collide awkwardly in one or two cases where it may be _implicit_ per the special case usage 
```swift
<value-containing>I am implicitly labeled</value-containing>
``` 
or _explicit_, as in 
```swift
<value-containing>
    <value>I am explicitly labeled</value>
</value-containing>
``` 
With the change proposed, the latter example will be unambiguously captured by
```swift
struct ValueContaining: Codable {
    let value: String
}
```
while the former is equivalent to
```swift
struct ValueContaining: Codable {
    let value: String

    enum CodingKeys: String, CodingKey {
        case value = ""
    }
}
```
## Source Compatability

This is a **breaking change** for downstream users of the special `"value"` coding key. All such uses should be replaced by `case value = ""` subject to this PR's inclusion.