### PR TITLE
Mixed choice/non-choice decoding

### DIFF
--- a/Tests/XMLCoderTests/MixedChoiceAndNonChoiceTests.swift
+++ b/Tests/XMLCoderTests/MixedChoiceAndNonChoiceTests.swift
@@ -8,12 +8,45 @@
 import XCTest
 import XMLCoder
 
+private enum AlternateIntOrString: Equatable {
+    case alternateInt(Int)
+    case alternateString(String)
+}
+
+extension AlternateIntOrString: Codable {
+    enum CodingKeys: String, CodingKey {
+        case alternateInt = "alternate-int"
+        case alternateString = "alternate-string"
+    }
+
+    func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        switch self {
+        case let .alternateInt(int):
+            try container.encode(int, forKey: .alternateInt)
+        case let .alternateString(string):
+            try container.encode(string, forKey: .alternateString)
+        }
+    }
+
+    init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        if container.contains(.alternateInt) {
+            self = .alternateInt(try container.decode(Int.self, forKey: .alternateInt))
+        } else {
+            self = .alternateString(try container.decode(String.self, forKey: .alternateString))
+        }
+    }
+}
+
+extension AlternateIntOrString.CodingKeys: XMLChoiceCodingKey {}
+
 private struct MixedIntOrStringFirst: Equatable {
     let intOrString: IntOrString
     let otherValue: String
 }
 
-extension MixedIntOrStringFirst: Encodable {
+extension MixedIntOrStringFirst: Codable {
     enum CodingKeys: String, CodingKey {
         case otherValue = "other-value"
     }
@@ -22,6 +55,12 @@ extension MixedIntOrStringFirst: Encodable {
         try intOrString.encode(to: encoder)
         var container = encoder.container(keyedBy: CodingKeys.self)
         try container.encode(otherValue, forKey: .otherValue)
+    }
+
+    init(from decoder: Decoder) throws {
+        intOrString = try IntOrString(from: decoder)
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        otherValue = try container.decode(String.self, forKey: .otherValue)
     }
 }
 
@@ -30,7 +69,7 @@ private struct MixedOtherFirst: Equatable {
     let otherValue: String
 }
 
-extension MixedOtherFirst: Encodable {
+extension MixedOtherFirst: Codable {
     enum CodingKeys: String, CodingKey {
         case otherValue = "other-value"
     }
@@ -40,15 +79,21 @@ extension MixedOtherFirst: Encodable {
         try container.encode(otherValue, forKey: .otherValue)
         try intOrString.encode(to: encoder)
     }
+
+    init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        otherValue = try container.decode(String.self, forKey: .otherValue)
+        intOrString = try IntOrString(from: decoder)
+    }
 }
 
-private struct MixedEitherSide {
+private struct MixedEitherSide: Equatable {
     let leading: String
     let intOrString: IntOrString
     let trailing: String
 }
 
-extension MixedEitherSide: Encodable {
+extension MixedEitherSide: Codable {
     enum CodingKeys: String, CodingKey {
         case leading
         case trailing
@@ -60,17 +105,29 @@ extension MixedEitherSide: Encodable {
         try intOrString.encode(to: encoder)
         try container.encode(trailing, forKey: .trailing)
     }
+
+    init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        leading = try container.decode(String.self, forKey: .leading)
+        intOrString = try IntOrString(from: decoder)
+        trailing = try container.decode(String.self, forKey: .trailing)
+    }
 }
 
-private struct TwoChoiceElements {
+private struct TwoChoiceElements: Equatable {
     let first: IntOrString
-    let second: IntOrString
+    let second: AlternateIntOrString
 }
 
-extension TwoChoiceElements: Encodable {
+extension TwoChoiceElements: Codable {
     func encode(to encoder: Encoder) throws {
         try first.encode(to: encoder)
         try second.encode(to: encoder)
+    }
+
+    init(from decoder: Decoder) throws {
+        first = try IntOrString(from: decoder)
+        second = try AlternateIntOrString(from: decoder)
     }
 }
 
@@ -82,11 +139,27 @@ class MixedChoiceAndNonChoiceTests: XCTestCase {
         XCTAssertEqual(String(data: firstEncoded, encoding: .utf8), firstExpectedXML)
     }
 
+    func testMixedChoiceFirstDecode() throws {
+        let xmlString = "<container><int>4</int><other-value>other</other-value></container>"
+        let xmlData = xmlString.data(using: .utf8)!
+        let decoded = try XMLDecoder().decode(MixedIntOrStringFirst.self, from: xmlData)
+        let expected = MixedIntOrStringFirst(intOrString: .int(4), otherValue: "other")
+        XCTAssertEqual(decoded, expected)
+    }
+
     func testMixedChoiceSecondEncode() throws {
         let second = MixedOtherFirst(intOrString: .int(4), otherValue: "other")
         let secondEncoded = try XMLEncoder().encode(second, withRootKey: "container")
         let secondExpectedXML = "<container><other-value>other</other-value><int>4</int></container>"
         XCTAssertEqual(String(data: secondEncoded, encoding: .utf8), secondExpectedXML)
+    }
+
+    func testMixedChoiceSecondDecode() throws {
+        let xmlString = "<container><other-value>other</other-value><int>4</int></container>"
+        let xmlData = xmlString.data(using: .utf8)!
+        let decoded = try XMLDecoder().decode(MixedOtherFirst.self, from: xmlData)
+        let expected = MixedOtherFirst(intOrString: .int(4), otherValue: "other")
+        XCTAssertEqual(decoded, expected)
     }
 
     func testMixedChoiceFlankedEncode() throws {
@@ -98,10 +171,28 @@ class MixedChoiceAndNonChoiceTests: XCTestCase {
         XCTAssertEqual(String(data: flankedEncoded, encoding: .utf8), flankedExpectedXML)
     }
 
+    func testMixedChoiceFlankedDecode() throws {
+        let xmlString = """
+        <container><leading>first</leading><string>then</string><trailing>second</trailing></container>
+        """
+        let xmlData = xmlString.data(using: .utf8)!
+        let decoded = try XMLDecoder().decode(MixedEitherSide.self, from: xmlData)
+        let expected = MixedEitherSide(leading: "first", intOrString: .string("then"), trailing: "second")
+        XCTAssertEqual(decoded, expected)
+    }
+
     func testTwoChoiceElementsEncode() throws {
-        let twoChoiceElements = TwoChoiceElements(first: .int(1), second: .string("one"))
+        let twoChoiceElements = TwoChoiceElements(first: .int(1), second: .alternateString("one"))
         let encoded = try XMLEncoder().encode(twoChoiceElements, withRootKey: "container")
-        let expectedXML = "<container><int>1</int><string>one</string></container>"
+        let expectedXML = "<container><int>1</int><alternate-string>one</alternate-string></container>"
         XCTAssertEqual(String(data: encoded, encoding: .utf8), expectedXML)
+    }
+
+    func testTwoChoiceElementsDecode() throws {
+        let xmlString = "<container><int>1</int><alternate-string>one</alternate-string></container>"
+        let xmlData = xmlString.data(using: .utf8)!
+        let decoded = try XMLDecoder().decode(TwoChoiceElements.self, from: xmlData)
+        let expected = TwoChoiceElements(first: .int(1), second: .alternateString("one"))
+        XCTAssertEqual(decoded, expected)
     }
 }

--- a/Tests/XMLCoderTests/XCTestManifests.swift
+++ b/Tests/XMLCoderTests/XCTestManifests.swift
@@ -419,9 +419,13 @@ extension MixedChoiceAndNonChoiceTests {
     //   `swift test --generate-linuxmain`
     // to regenerate.
     static let __allTests__MixedChoiceAndNonChoiceTests = [
+        ("testMixedChoiceFirstDecode", testMixedChoiceFirstDecode),
         ("testMixedChoiceFirstEncode", testMixedChoiceFirstEncode),
+        ("testMixedChoiceFlankedDecode", testMixedChoiceFlankedDecode),
         ("testMixedChoiceFlankedEncode", testMixedChoiceFlankedEncode),
+        ("testMixedChoiceSecondDecode", testMixedChoiceSecondDecode),
         ("testMixedChoiceSecondEncode", testMixedChoiceSecondEncode),
+        ("testTwoChoiceElementsDecode", testTwoChoiceElementsDecode),
         ("testTwoChoiceElementsEncode", testTwoChoiceElementsEncode),
     ]
 }


### PR DESCRIPTION
Mirrors #154 

Fixes bugs 
1) Decoding multiple choice elements in the same Keyed Container.
2) Decoding choice elements after decoding regular keyed elements in the same container.

Case 1 refers to decoding implementations of the form: 
```swift
    init(from decoder: Decoder) throws {
        let container = try decoder.container(keyedBy: CodingKeys.self)
        otherValue = try container.decode(String.self, forKey: .otherValue)
        intOrString = try IntOrString(from: decoder)
    }
```
where `IntOrString` is a choice coding element

<details><summary>(<code>IntOrString</code> defined as follows) </summary>
<p>

```swift 
enum IntOrString {
    case int(Int)
    case string(String)
}

extension IntOrString: Decodable {
    enum CodingKeys: String, CodingKey {
        case int
        case string
    }

    init(from decoder: Decoder) throws {
        let container = try decoder.container(keyedBy: CodingKeys.self)
        if container.contains(.int) {
            self = .int(try container.decode(Int.self, forKey: .int))
        } else {
            self = .string(try container.decode(String.self, forKey: .string))
        }
    }
}

extension IntOrString.CodingKeys: XMLChoiceCodingKey {} // signifies that `IntOrString` is a choice element
```

</p>
</details>

Case 2 refers to decoding implementations of the following form:

```swift
    init(from decoder: Decoder) throws {
        self.first = try IntOrString(from: decoder)
        self.second = try AlternateIntOrString(from: decoder)
    }
```

Where both `first: IntOrString` and `second: AlternateIntOrString` are choice elements.

<details><summary>(<code>AlternateIntOrString</code> defined as follows) </summary>
<p>

```swift
private enum AlternateIntOrString {
    case alternateInt(Int)
    case alternateString(String)
}

extension AlternateIntOrString: Decodable {
    enum CodingKeys: String, CodingKey {
        case alternateInt = "alternate-int"
        case alternateString = "alternate-string"
    }

    init(from decoder: Decoder) throws {
        let container = try decoder.container(keyedBy: CodingKeys.self)
        if container.contains(.alternateInt) {
            self = .alternateInt(try container.decode(Int.self, forKey: .alternateInt))
        } else {
            self = .alternateString(try container.decode(String.self, forKey: .alternateString))
        }
    }
}

extension AlternateIntOrString.CodingKeys: XMLChoiceCodingKey {} // signifies that `AlternateIntOrString` is a choice element
```

</p>
</details>