### PR TITLE
Support for mixed-content nodes

### DIFF
--- a/Sources/XMLCoder/Auxiliaries/KeyedStorage.swift
+++ b/Sources/XMLCoder/Auxiliaries/KeyedStorage.swift
@@ -77,11 +77,12 @@ extension KeyedStorage where Key == String, Value == Box {
 
         let hasElements = !element.elements.isEmpty
         let hasAttributes = !element.attributes.isEmpty
+        let hasText = element.stringValue != nil
 
         if hasElements || hasAttributes {
             result.append(element.transformToBoxTree(), at: element.key)
-        } else if let value = element.value {
-            result.append(StringBox(value), at: element.key)
+        } else if hasText {
+            result.append(element.transformToBoxTree(), at: element.key)
         } else {
             result.append(SingleKeyedBox(key: element.key, element: NullBox()), at: element.key)
         }

--- a/Sources/XMLCoder/Auxiliaries/XMLStackParser.swift
+++ b/Sources/XMLCoder/Auxiliaries/XMLStackParser.swift
@@ -26,7 +26,7 @@ class XMLStackParser: NSObject {
         errorContextLength length: UInt,
         shouldProcessNamespaces: Bool,
         trimValueWhitespaces: Bool
-    ) throws -> KeyedBox {
+    ) throws -> Box {
         let parser = XMLStackParser(trimValueWhitespaces: trimValueWhitespaces)
 
         let node = try parser.parse(
@@ -159,8 +159,13 @@ extension XMLStackParser: XMLParserDelegate {
     }
 
     func parser(_: XMLParser, foundCharacters string: String) {
+        let processedString = process(string: string)
+        guard processedString.count > 0, string.count != 0 else {
+            return
+        }
+
         withCurrentElement { currentElement in
-            currentElement.append(value: process(string: string))
+            currentElement.append(string: processedString)
         }
     }
 
@@ -170,7 +175,7 @@ extension XMLStackParser: XMLParserDelegate {
         }
 
         withCurrentElement { currentElement in
-            currentElement.append(value: process(string: string))
+            currentElement.append(cdata: string)
         }
     }
 }

--- a/Sources/XMLCoder/Decoder/XMLDecoderImplementation.swift
+++ b/Sources/XMLCoder/Decoder/XMLDecoderImplementation.swift
@@ -212,9 +212,13 @@ extension XMLDecoderImplementation {
             else { throw error }
             return value
         case let singleKeyedBox as SingleKeyedBox:
-            guard let value = singleKeyedBox.element as? B
-            else { throw error }
-            return value
+            if let value = singleKeyedBox.element as? B {
+                return value
+            } else if let box = singleKeyedBox.element as? KeyedBox, let value = box.elements[""].first as? B {
+                return value
+            } else {
+                throw error
+            }
         case is NullBox:
             throw error
         case let keyedBox as KeyedBox:

--- a/Sources/XMLCoder/Decoder/XMLKeyedDecodingContainer.swift
+++ b/Sources/XMLCoder/Decoder/XMLKeyedDecodingContainer.swift
@@ -162,7 +162,7 @@ struct XMLKeyedDecodingContainer<K: CodingKey>: KeyedDecodingContainerProtocol {
 
         let elements = container.unboxed.elements[key.stringValue]
 
-        if let containsKeyed = elements as? [KeyedBox], let keyed = containsKeyed.first {
+        if let containsKeyed = elements as? [KeyedBox], containsKeyed.count == 1, let keyed = containsKeyed.first {
             return XMLUnkeyedDecodingContainer(
                 referencing: decoder,
                 wrapping: SharedBox(keyed.elements.map(SingleKeyedBox.init))

--- a/Tests/XMLCoderTests/Auxiliary/XMLElementTests.swift
+++ b/Tests/XMLCoderTests/Auxiliary/XMLElementTests.swift
@@ -13,7 +13,7 @@ class XMLElementTests: XCTestCase {
         let null = XMLCoderElement(key: "foo")
 
         XCTAssertEqual(null.key, "foo")
-        XCTAssertNil(null.value)
+        XCTAssertNil(null.stringValue)
         XCTAssertEqual(null.elements, [])
         XCTAssertEqual(null.attributes, [])
     }
@@ -22,7 +22,7 @@ class XMLElementTests: XCTestCase {
         let keyed = XMLCoderElement(key: "foo", box: UnkeyedBox())
 
         XCTAssertEqual(keyed.key, "foo")
-        XCTAssertNil(keyed.value)
+        XCTAssertNil(keyed.stringValue)
         XCTAssertEqual(keyed.elements, [])
         XCTAssertEqual(keyed.attributes, [])
     }
@@ -34,17 +34,18 @@ class XMLElementTests: XCTestCase {
         ))
 
         XCTAssertEqual(keyed.key, "foo")
-        XCTAssertNil(keyed.value)
+        XCTAssertNil(keyed.stringValue)
         XCTAssertEqual(keyed.elements, [])
         XCTAssertEqual(keyed.attributes, [Attribute(key: "blee", value: "42")])
     }
 
     func testInitSimple() {
         let keyed = XMLCoderElement(key: "foo", box: StringBox("bar"))
+        let element = XMLCoderElement(stringValue: "bar")
 
         XCTAssertEqual(keyed.key, "foo")
-        XCTAssertEqual(keyed.value, "bar")
-        XCTAssertEqual(keyed.elements, [])
+        XCTAssertNil(keyed.stringValue)
+        XCTAssertEqual(keyed.elements, [element])
         XCTAssertEqual(keyed.attributes, [])
     }
 }

--- a/Tests/XMLCoderTests/Auxiliary/XMLStackParserTests.swift
+++ b/Tests/XMLCoderTests/Auxiliary/XMLStackParserTests.swift
@@ -29,15 +29,14 @@ class XMLStackParserTests: XCTestCase {
 
         let expected = XMLCoderElement(
             key: "container",
-            value: "",
             elements: [
                 XMLCoderElement(
                     key: "value",
-                    value: "42"
+                    stringValue: "42"
                 ),
                 XMLCoderElement(
                     key: "data",
-                    value: "lorem ipsum"
+                    cdataValue: "lorem ipsum"
                 ),
             ]
         )

--- a/Tests/XMLCoderTests/Minimal/BoxTreeTests.swift
+++ b/Tests/XMLCoderTests/Minimal/BoxTreeTests.swift
@@ -12,24 +12,21 @@ class BoxTreeTests: XCTestCase {
     func testNestedValues() throws {
         let e1 = XMLCoderElement(
             key: "foo",
-            value: "456",
-            elements: [],
+            stringValue: "456",
             attributes: [Attribute(key: "id", value: "123")]
         )
         let e2 = XMLCoderElement(
             key: "foo",
-            value: "123",
-            elements: [],
+            stringValue: "123",
             attributes: [Attribute(key: "id", value: "789")]
         )
         let root = XMLCoderElement(
             key: "container",
-            value: nil,
             elements: [e1, e2],
             attributes: []
         )
 
-        let boxTree = root.transformToBoxTree()
+        let boxTree = root.transformToBoxTree() as! KeyedBox
         let foo = boxTree.elements["foo"]
         XCTAssertEqual(foo.count, 2)
     }

--- a/Tests/XMLCoderTests/Minimal/BoxTreeTests.swift
+++ b/Tests/XMLCoderTests/Minimal/BoxTreeTests.swift
@@ -26,8 +26,8 @@ class BoxTreeTests: XCTestCase {
             attributes: []
         )
 
-        let boxTree = root.transformToBoxTree() as! KeyedBox
-        let foo = boxTree.elements["foo"]
-        XCTAssertEqual(foo.count, 2)
+        let boxTree = root.transformToBoxTree() as? KeyedBox
+        let foo = boxTree?.elements["foo"]
+        XCTAssertEqual(foo?.count, 2)
     }
 }

--- a/Tests/XMLCoderTests/Minimal/MixedContentTests.swift
+++ b/Tests/XMLCoderTests/Minimal/MixedContentTests.swift
@@ -1,0 +1,65 @@
+//
+//  MixedContentTests.swift
+//  XMLCoderTests
+//
+//  Created by Christopher Williams on 11/21/19.
+//
+
+import Foundation
+
+import XCTest
+@testable import XMLCoder
+
+class MixedContentTests: XCTestCase {
+    enum TextItem: Codable, Equatable {
+        case bold(String)
+        case text(String)
+
+        enum CodingKeys: String, XMLChoiceCodingKey {
+            case bold = "b"
+            case text = ""
+        }
+
+        func encode(to encoder: Encoder) throws {
+            var container = encoder.container(keyedBy: CodingKeys.self)
+            switch self {
+            case let .text(text):
+                try container.encode(text, forKey: .text)
+            case let .bold(text):
+                try container.encode(text, forKey: .bold)
+            }
+        }
+
+        init(from decoder: Decoder) throws {
+            let container = try decoder.container(keyedBy: CodingKeys.self)
+            let key = container.allKeys.first!
+            switch key {
+            case .bold:
+                let string = try container.decode(String.self, forKey: .bold)
+                self = .bold(string)
+            case .text:
+                let string = try container.decode(String.self, forKey: .text)
+                self = .text(string)
+            }
+        }
+    }
+
+    func testMixed() throws {
+        let decoder = XMLDecoder()
+        let encoder = XMLEncoder()
+
+        let xmlString =
+            """
+            <container>first<b>bold text</b>second</container>
+            """
+
+        let xmlData = xmlString.data(using: .utf8)!
+
+        let decoded = try decoder.decode([TextItem].self, from: xmlData)
+        XCTAssertEqual(decoded, [.text("first"), .bold("bold text"), .text("second")])
+
+        let encoded = try encoder.encode(decoded, withRootKey: "container")
+        let encodedString = String(data: encoded, encoding: .utf8)
+        XCTAssertEqual(encodedString, xmlString)
+    }
+}


### PR DESCRIPTION
Adding support for nodes with mixed content, where loose text nodes might coexist with other  node types. An example of this in the tests is: `<container>first<b>bold text</b>second</container>`.

This restructures the contents of nodes, so that raw text is always stored in a `""`-keyed node, which can occur multiple times if necessary. Previously all text nodes were appended together into the element's `value`, so their order relative to elements between them was lost.