### PR TITLE
Make TopLevelEncoder implementation overridable

### DIFF
--- a/Sources/XMLCoder/Decoder/XMLDecoder.swift
+++ b/Sources/XMLCoder/Decoder/XMLDecoder.swift
@@ -382,10 +382,5 @@ import protocol OpenCombine.TopLevelEncoder
 
 #if canImport(Combine) || canImport(OpenCombine)
 extension XMLDecoder: TopLevelDecoder {}
-
-extension XMLEncoder: TopLevelEncoder {
-    public func encode<T>(_ value: T) throws -> Data where T: Encodable {
-        try encode(value, withRootKey: nil, rootAttributes: nil, header: nil)
-    }
-}
+extension XMLEncoder: TopLevelEncoder {}
 #endif

--- a/Sources/XMLCoder/Encoder/XMLEncoder.swift
+++ b/Sources/XMLCoder/Encoder/XMLEncoder.swift
@@ -380,7 +380,7 @@ open class XMLEncoder {
     // MARK: - TopLevelEncoder
 
     open func encode<T>(_ value: T) throws -> Data where T: Encodable {
-        try encode(value, withRootKey: nil, rootAttributes: nil, header: nil)
+        return try encode(value, withRootKey: nil, rootAttributes: nil, header: nil)
     }
 }
 

--- a/Sources/XMLCoder/Encoder/XMLEncoder.swift
+++ b/Sources/XMLCoder/Encoder/XMLEncoder.swift
@@ -379,9 +379,11 @@ open class XMLEncoder {
 
     // MARK: - TopLevelEncoder
 
+    #if canImport(Combine) || canImport(OpenCombine)
     open func encode<T>(_ value: T) throws -> Data where T: Encodable {
         return try encode(value, withRootKey: nil, rootAttributes: nil, header: nil)
     }
+    #endif
 }
 
 private extension String {

--- a/Sources/XMLCoder/Encoder/XMLEncoder.swift
+++ b/Sources/XMLCoder/Encoder/XMLEncoder.swift
@@ -376,6 +376,12 @@ open class XMLEncoder {
         return element.toXMLString(with: header, formatting: outputFormatting)
             .data(using: .utf8, allowLossyConversion: true)!
     }
+
+    // MARK: - TopLevelEncoder
+
+    open func encode<T>(_ value: T) throws -> Data where T: Encodable {
+        try encode(value, withRootKey: nil, rootAttributes: nil, header: nil)
+    }
 }
 
 private extension String {

--- a/Tests/XMLCoderTests/CombineTests.swift
+++ b/Tests/XMLCoderTests/CombineTests.swift
@@ -29,7 +29,7 @@ private struct Foo: Codable {
 
 final class CustomEncoder: XMLEncoder {
     override func encode<T>(_ value: T) throws -> Data where T : Encodable {
-        try self.encode(value, withRootKey: "bar", rootAttributes: nil, header: nil)
+        return try self.encode(value, withRootKey: "bar", rootAttributes: nil, header: nil)
     }
 }
 

--- a/Tests/XMLCoderTests/CombineTests.swift
+++ b/Tests/XMLCoderTests/CombineTests.swift
@@ -28,8 +28,8 @@ private struct Foo: Codable {
 }
 
 final class CustomEncoder: XMLEncoder {
-    override func encode<T>(_ value: T) throws -> Data where T : Encodable {
-        return try self.encode(value, withRootKey: "bar", rootAttributes: nil, header: nil)
+    override func encode<T>(_ value: T) throws -> Data where T: Encodable {
+        return try encode(value, withRootKey: "bar", rootAttributes: nil, header: nil)
     }
 }
 

--- a/Tests/XMLCoderTests/CombineTests.swift
+++ b/Tests/XMLCoderTests/CombineTests.swift
@@ -27,6 +27,12 @@ private struct Foo: Codable {
     var name: String
 }
 
+final class CustomEncoder: XMLEncoder {
+    override func encode<T>(_ value: T) throws -> Data where T : Encodable {
+        try self.encode(value, withRootKey: "bar", rootAttributes: nil, header: nil)
+    }
+}
+
 @available(iOS 13.0, macOS 10.15.0, tvOS 13.0, watchOS 6.0, *)
 final class CombineTests: XCTestCase {
     func testDecode() {
@@ -50,6 +56,22 @@ final class CombineTests: XCTestCase {
                 }
             )
         XCTAssertEqual(foo?.name, "Foo")
+    }
+
+    func testCustomEncode() {
+        var foo: Data?
+        _ = Just(Foo(name: "Foo"))
+            .encode(encoder: CustomEncoder())
+            .sink(
+                receiveCompletion: { _ in },
+                receiveValue: {
+                    foo = $0
+                }
+            )
+        XCTAssertEqual(
+            String(data: foo!, encoding: .utf8)!,
+            "<bar><name>Foo</name></bar>"
+        )
     }
 }
 #endif


### PR DESCRIPTION
`TopLevelEncoder` implementation was added by #175. However, its method cannot be overridden. If it can be, we can use custom root key, root attributes, or header even when we use Combine-style like this:

```swift
final class MyEncoder: XMLEncoder {
    override func encode<T>(_ value: T) throws -> Data where T : Encodable {
        try self.encode(value, withRootKey: "foo", rootAttributes: nil, header: XMLHeader(version: 1.0, encoding: "UTF-8"))
    }
}
```

So, I proposed the solution.