### PR TITLE
Add convert from UPPERCASE decoding key strategy

### DIFF
--- a/Sources/XMLCoder/Decoder/XMLDecoder.swift
+++ b/Sources/XMLCoder/Decoder/XMLDecoder.swift
@@ -158,6 +158,9 @@ open class XMLDecoder {
         /// Convert from "CodingKey" to "codingKey"
         case convertFromCapitalized
 
+        /// Convert from "CODING_KEY" to "codingKey"
+        case convertFromUppercase
+
         /// Provide a custom conversion from the key in the encoded XML to the
         /// keys specified by the decoded types.
         /// The full path to the current decoding position is provided for
@@ -175,6 +178,10 @@ open class XMLDecoder {
             let firstLetter = stringKey.prefix(1).lowercased()
             let result = firstLetter + stringKey.dropFirst()
             return result
+        }
+
+        static func _convertFromUppercase(_ stringKey: String) -> String {
+          _convert(stringKey.lowercased(), usingSeparator: "_")
         }
 
         static func _convertFromSnakeCase(_ stringKey: String) -> String {

--- a/Sources/XMLCoder/Decoder/XMLDecoderImplementation.swift
+++ b/Sources/XMLCoder/Decoder/XMLDecoderImplementation.swift
@@ -482,6 +482,8 @@ extension XMLDecoderImplementation {
             return XMLDecoder.KeyDecodingStrategy._convertFromSnakeCase
         case .convertFromCapitalized:
             return XMLDecoder.KeyDecodingStrategy._convertFromCapitalized
+        case .convertFromUppercase:
+            return XMLDecoder.KeyDecodingStrategy._convertFromUppercase
         case .convertFromKebabCase:
             return XMLDecoder.KeyDecodingStrategy._convertFromKebabCase
         case .useDefaultKeys:

--- a/Tests/XMLCoderTests/Minimal/KeyedTests.swift
+++ b/Tests/XMLCoderTests/Minimal/KeyedTests.swift
@@ -129,6 +129,26 @@ class KeyedTests: XCTestCase {
         XCTAssertThrowsError(try decoder.decode(ContainerCamelCase.self, from: xmlData))
     }
 
+    func testConvertFromAllCaps() throws {
+        let decoder = XMLDecoder()
+        decoder.keyDecodingStrategy = .convertFromUppercase
+
+        let xmlString =
+            """
+            <CONTAINER TEST_ATTRIBUTE="test_container">
+                <VAL_UE>
+                    <FOO>12</FOO>
+                </VAL_UE>
+            </CONTAINER>
+            """
+        let xmlData = xmlString.data(using: .utf8)!
+
+        let decoded = try decoder.decode(ContainerCamelCase.self, from: xmlData)
+
+        XCTAssertEqual(decoded.valUe, ["foo": 12])
+    }
+
+
     func testCustomDecoderConvert() throws {
         let decoder = XMLDecoder()
         decoder.keyDecodingStrategy = .custom { keys in

--- a/Tests/XMLCoderTests/Minimal/KeyedTests.swift
+++ b/Tests/XMLCoderTests/Minimal/KeyedTests.swift
@@ -148,7 +148,6 @@ class KeyedTests: XCTestCase {
         XCTAssertEqual(decoded.valUe, ["foo": 12])
     }
 
-
     func testCustomDecoderConvert() throws {
         let decoder = XMLDecoder()
         decoder.keyDecodingStrategy = .custom { keys in


### PR DESCRIPTION
This will convert from `ALL_CAPS_SNAKE_CASE` to `camelCase`.

Previously, there was only snake_case, kebab-case, and first-letter-only Capitalised. To do ALL_CAPS, one needed to use a custom key decoding strategy.

I've been using this to make a decoder for [BeerXML](http://www.beerxml.com), which tends to have the keys capitalised.
