### PR TITLE
Remove unneeded parameter `key`

### DIFF
--- a/Sources/XMLCoder/Auxiliaries/XMLCoderElement.swift
+++ b/Sources/XMLCoder/Auxiliaries/XMLCoderElement.swift
@@ -75,7 +75,7 @@ struct XMLCoderElement: Equatable {
         stringValue = string
     }
 
-    mutating func append(element: XMLCoderElement, forKey key: String) {
+    mutating func append(element: XMLCoderElement) {
         elements.append(element)
         containsTextNodes = containsTextNodes || element.isTextNode
     }

--- a/Sources/XMLCoder/Auxiliaries/XMLStackParser.swift
+++ b/Sources/XMLCoder/Auxiliaries/XMLStackParser.swift
@@ -148,7 +148,7 @@ extension XMLStackParser: XMLParserDelegate {
         let updatedElement = removeWhitespaceElements ? elementWithFilteredElements(element: element) : element
     
         withCurrentElement { currentElement in
-            currentElement.append(element: updatedElement, forKey: updatedElement.key)
+            currentElement.append(element: updatedElement)
         }
 
         if stack.isEmpty {


### PR DESCRIPTION
The parameter was not used inside the method and only had one call-site

Please ignore if you are planning to use the parameter in some way.

All tests are passing