### PR TITLE
Fix `trimValueWhitespaces` removing needed white-spaces

### DIFF
--- a/Sources/XMLCoder/Auxiliaries/XMLCoderElement.swift
+++ b/Sources/XMLCoder/Auxiliaries/XMLCoderElement.swift
@@ -100,6 +100,13 @@ struct XMLCoderElement: Equatable {
         containsTextNodes = true
     }
 
+    mutating func trimTextNodes() {
+        guard containsTextNodes else { return }
+        for idx in elements.indices {
+            elements[idx].stringValue = elements[idx].stringValue?.trimmingCharacters(in: .whitespacesAndNewlines)
+        }
+    }
+
     func transformToBoxTree() -> Box {
         if isTextNode {
             return StringBox(stringValue!)

--- a/Sources/XMLCoder/Auxiliaries/XMLStackParser.swift
+++ b/Sources/XMLCoder/Auxiliaries/XMLStackParser.swift
@@ -109,8 +109,7 @@ class XMLStackParser: NSObject {
         try body(&stack[stack.count - 1])
     }
 
-    /// Trim whitespaces for a given string if needed.
-    func process(string: String) -> String {
+    func trimWhitespacesIfNeeded(_ string: String) -> String {
         return trimValueWhitespaces
             ? string.trimmingCharacters(in: .whitespacesAndNewlines)
             : string
@@ -141,12 +140,15 @@ extension XMLStackParser: XMLParserDelegate {
                 namespaceURI _: String?,
                 qualifiedName _: String?)
     {
-        guard let element = stack.popLast() else {
+        guard var element = stack.popLast() else {
             return
+        }
+        if trimValueWhitespaces && element.containsTextNodes {
+            element.trimTextNodes()
         }
 
         let updatedElement = removeWhitespaceElements ? elementWithFilteredElements(element: element) : element
-    
+
         withCurrentElement { currentElement in
             currentElement.append(element: updatedElement, forKey: updatedElement.key)
         }
@@ -176,13 +178,13 @@ extension XMLStackParser: XMLParserDelegate {
     }
 
     func parser(_: XMLParser, foundCharacters string: String) {
-        let processedString = process(string: string)
+        let processedString = trimWhitespacesIfNeeded(string)
         guard processedString.count > 0, string.count != 0 else {
             return
         }
 
         withCurrentElement { currentElement in
-            currentElement.append(string: processedString)
+            currentElement.append(string: string)
         }
     }
 

--- a/Tests/XMLCoderTests/Auxiliary/XMLStackParserTests.swift
+++ b/Tests/XMLCoderTests/Auxiliary/XMLStackParserTests.swift
@@ -56,7 +56,7 @@ class XMLStackParserTests: XCTestCase {
             shouldProcessNamespaces: false
         ))
     }
-    
+
     func testNestedMembers_removeWhitespaceElements() throws {
         let parser = XMLStackParser(trimValueWhitespaces: false, removeWhitespaceElements: true)
         let xmlData =

--- a/Tests/XMLCoderTests/SpacePreserveTest.swift
+++ b/Tests/XMLCoderTests/SpacePreserveTest.swift
@@ -37,6 +37,14 @@ private let jaCharacterXML = """
 <t>\(jaCharacterString)</t>
 """.data(using: .utf8)!
 
+private let deCharacterXMLNested = """
+<si><t xml:space="preserve">\(deCharacterString)</t></si>
+""".data(using: .utf8)!
+
+private let deCharacterXMLSpaced = """
+<t>     \(deCharacterString)    </t>
+""".data(using: .utf8)!
+
 private struct Item: Codable, Equatable {
     public let text: String?
 
@@ -96,4 +104,21 @@ final class SpacePreserveTest: XCTestCase {
         let resultJapanese = try decoder.decode(String.self, from: jaCharacterXML)
         XCTAssertEqual(resultJapanese, jaCharacterString)
     }
+
+    func testNonStandardCharactersNested() throws {
+        let decoder = XMLDecoder(trimValueWhitespaces: true)
+
+        let resultGerman = try decoder.decode(Item.self, from: deCharacterXMLNested)
+
+        XCTAssertEqual(resultGerman, Item(text: deCharacterString))
+    }
+
+    func testNonStandardCharactersSpaced() throws {
+        let decoder = XMLDecoder(trimValueWhitespaces: false)
+
+        let resultGerman = try decoder.decode(String.self, from: deCharacterXMLSpaced)
+
+        XCTAssertEqual(resultGerman, "     \(deCharacterString)    ")
+    }
+
 }

--- a/Tests/XMLCoderTests/SpacePreserveTest.swift
+++ b/Tests/XMLCoderTests/SpacePreserveTest.swift
@@ -27,6 +27,16 @@ private let nestedCopyrightXML = """
 <si><t>\(copyright)</t></si>
 """.data(using: .utf8)!
 
+private let deCharacterString = "Stilles Örtchen"
+private let deCharacterXML = """
+<t>\(deCharacterString)</t>
+""".data(using: .utf8)!
+
+private let jaCharacterString = "Music 音楽"
+private let jaCharacterXML = """
+<t>\(jaCharacterString)</t>
+""".data(using: .utf8)!
+
 private struct Item: Codable, Equatable {
     public let text: String?
 
@@ -75,5 +85,15 @@ final class SpacePreserveTest: XCTestCase {
 
         let item = try decoder.decode(Item.self, from: nestedCopyrightXML)
         XCTAssertEqual(item, Item(text: copyright))
+    }
+
+    func testNonStandardCharacters() throws {
+        let decoder = XMLDecoder()
+        decoder.trimValueWhitespaces = true
+        let resultGerman = try decoder.decode(String.self, from: deCharacterXML)
+        XCTAssertEqual(resultGerman, deCharacterString)
+
+        let resultJapanese = try decoder.decode(String.self, from: jaCharacterXML)
+        XCTAssertEqual(resultJapanese, jaCharacterString)
     }
 }


### PR DESCRIPTION
Hello everyone!

I found that the logic for trimming white-spaces (`trimValueWhitespaces`) may inadvertently remove white-spaces from inside the string value of the element, if `XMLParser` reports the content of a single element as multiple strings.  

This happens for example with non-ascii characters like German umlauts:
`Lösen` is split up and reported separately as `L` and `ösen`.
Or where we have "mixed" strings, e.g. containing a segment of Japanese or Chinese characters:
`Japanese 日本語` is split into `Japanese` and ` 日本語`.

If there's a white-space adjacent to the split, as in the Japanese example above, the white-space gets trimmed **before** it's joined together. Resulting in `Japanese日本語` without a space in the middle.

I added failing tests with the first commit.

---
see also: https://stackoverflow.com/a/1076951/2064473

> The parser object may send the delegate several parser:foundCharacters: messages to report the characters of an element. Because string **may be only part of the total character content for the current element**, you should append it to the current accumulation of characters until the element changes.