### PR TITLE
Remove some of the swiftlint generated warnings

### DIFF
--- a/Sources/XMLCoder/Auxiliaries/XMLStackParser.swift
+++ b/Sources/XMLCoder/Auxiliaries/XMLStackParser.swift
@@ -146,7 +146,7 @@ extension XMLStackParser: XMLParserDelegate {
         }
 
         let updatedElement = removeWhitespaceElements ? elementWithFilteredElements(element: element) : element
-    
+
         withCurrentElement { currentElement in
             currentElement.append(element: updatedElement, forKey: updatedElement.key)
         }

--- a/Sources/XMLCoder/Decoder/DecodingErrorExtension.swift
+++ b/Sources/XMLCoder/Decoder/DecodingErrorExtension.swift
@@ -8,9 +8,7 @@
 
 import Foundation
 
-//===----------------------------------------------------------------------===//
-// Error Utilities
-//===----------------------------------------------------------------------===//
+// MARK: - Error Utilities
 
 extension DecodingError {
     /// Returns a `.typeMismatch` error describing the expected type.

--- a/Sources/XMLCoder/Decoder/XMLDecoder.swift
+++ b/Sources/XMLCoder/Decoder/XMLDecoder.swift
@@ -8,9 +8,7 @@
 
 import Foundation
 
-//===----------------------------------------------------------------------===//
-// XML Decoder
-//===----------------------------------------------------------------------===//
+// MARK: - XML Decoder
 
 /// `XMLDecoder` facilitates the decoding of XML into semantic `Decodable` types.
 open class XMLDecoder {

--- a/Tests/XMLCoderTests/Auxiliary/XMLElementTests.swift
+++ b/Tests/XMLCoderTests/Auxiliary/XMLElementTests.swift
@@ -49,7 +49,7 @@ class XMLElementTests: XCTestCase {
         XCTAssertEqual(keyed.elements, [element])
         XCTAssertEqual(keyed.attributes, [])
     }
-    
+
     func testWhitespaceWithNoElements_keyed() {
         let keyed = XMLCoderElement(key: "foo", isStringBoxCDATA: false, box: StringBox("bar"))
         XCTAssertFalse(keyed.isWhitespaceWithNoElements())
@@ -95,7 +95,7 @@ class XMLElementTests: XCTestCase {
         <Input xmlns="https://example.com"><Nested xmlns:xsi="https://example.com" xsi:someName="nestedAttrValue"></Nested></Input>
         """)
     }
-    
+
     func testNestedElementWith_Namespace_Attribute_Element() {
         typealias Attribute = XMLCoderElement.Attribute
         typealias Element = XMLCoderElement

--- a/Tests/XMLCoderTests/Auxiliary/XMLStackParserTests.swift
+++ b/Tests/XMLCoderTests/Auxiliary/XMLStackParserTests.swift
@@ -56,7 +56,7 @@ class XMLStackParserTests: XCTestCase {
             shouldProcessNamespaces: false
         ))
     }
-    
+
     func testNestedMembers_removeWhitespaceElements() throws {
         let parser = XMLStackParser(trimValueWhitespaces: false, removeWhitespaceElements: true)
         let xmlData =
@@ -110,7 +110,7 @@ class XMLStackParserTests: XCTestCase {
 
         XCTAssertEqual(root.elements[0].key, "")
         XCTAssertEqual(root.elements[0].stringValue, "\n    ")
-        
+
         XCTAssertEqual(root.elements[1].key, "nestedStringList")
         XCTAssertEqual(root.elements[1].elements[0].key, "")
         XCTAssertEqual(root.elements[1].elements[0].stringValue, "\n        ")
@@ -127,7 +127,7 @@ class XMLStackParserTests: XCTestCase {
         XCTAssertEqual(root.elements[1].elements[3].elements[3].key, "member")
         XCTAssertEqual(root.elements[1].elements[3].elements[3].elements[0].stringValue, "qux")
     }
-    
+
     func testEscapableCharacters_removeWhitespaceElements() throws {
         let parser = XMLStackParser(trimValueWhitespaces: false, removeWhitespaceElements: true)
         let xmlData =
@@ -142,7 +142,7 @@ class XMLStackParserTests: XCTestCase {
         XCTAssertEqual(root.elements[0].key, "strValue")
         XCTAssertEqual(root.elements[0].elements[0].stringValue, "escaped data: &lt;\r\n")
     }
-    
+
     func testEscapableCharacters() throws {
         let parser = XMLStackParser(trimValueWhitespaces: false, removeWhitespaceElements: false)
         let xmlData =

--- a/Tests/XMLCoderTests/Minimal/NestedStringList.swift
+++ b/Tests/XMLCoderTests/Minimal/NestedStringList.swift
@@ -28,10 +28,10 @@ class NestedStringList: XCTestCase {
             let containerValues = try decoder.container(keyedBy: CodingKeys.self)
             let nestedStringListWrappedContainer = try containerValues.nestedContainer(keyedBy: NestedMemberKeys.self, forKey: .nestedStringList)
             let nestedStringListContainer = try nestedStringListWrappedContainer.decodeIfPresent([[String]].self, forKey: .member)
-            var nestedStringListBuffer:[[String]] = []
+            var nestedStringListBuffer: [[String]] = []
             if let nestedStringListContainer = nestedStringListContainer {
                 nestedStringListBuffer = [[String]]()
-                var listBuffer0: [String]? = nil
+                var listBuffer0: [String]?
                 for listContainer0 in nestedStringListContainer {
                     listBuffer0 = [String]()
                     for stringContainer1 in listContainer0 {

--- a/Tests/XMLCoderTests/Minimal/StringTests.swift
+++ b/Tests/XMLCoderTests/Minimal/StringTests.swift
@@ -16,8 +16,7 @@ class StringTests: XCTestCase {
     }
 
     let values: [(Value, String)] = [
-        // FIXME!
-        // ("", ""),
+        ("", ""),
         ("false", "false"),
         ("-42", "-42"),
         ("42", "42"),


### PR DESCRIPTION
This PR tends to some of the warnings generated by swiftlint.  

Please feel free to adjust if the changes don't work for you.

The FIXME on the test values in StringTests.swift:19 seems to actually be fixed somehow because the tests are passing without any adjustment.