### PR TITLE
Simplify string isAllWhitespace implementation

### DIFF
--- a/Sources/XMLCoder/Auxiliaries/String+Extensions.swift
+++ b/Sources/XMLCoder/Auxiliaries/String+Extensions.swift
@@ -47,6 +47,6 @@ extension StringProtocol {
 
 extension String {
     func isAllWhitespace() -> Bool {
-        return self.trimmingCharacters(in: .whitespacesAndNewlines) == ""
+        return unicodeScalars.allSatisfy(CharacterSet.whitespacesAndNewlines.contains)
     }
 }


### PR DESCRIPTION
This patch is really very simple one, but I believe can be both a simplification on implementation and a perf improvement in the sense that as it is if we take for example as reference the implementation of [`trimmingCharacters`](https://github.com/apple/swift-corelibs-foundation/blob/34887cb2615e903cbe7ad428a538ee27be5a7d39/Sources/Foundation/NSString.swift#L1162) we note that it will do a lot extra work as allocating buffers or a whole new string maybe, when this only need a simple check that can exit early and also avoid those extra allocations. 

I'm not sure if is significant, because I cannot tell if this is used in hot paths within the project and also I didn't measure, so perf improvement is just a guess that makes sense to me, and since it was a simple change I thought in open the PR. So let me know if this makes sense :) 
 