### PR TITLE
Pass root attributes as list of tuples to preserve ordering

### DIFF
--- a/Sources/XMLCoder/Encoder/XMLEncoder.swift
+++ b/Sources/XMLCoder/Encoder/XMLEncoder.swift
@@ -360,7 +360,7 @@ open class XMLEncoder {
     /// - throws: An error if any value throws an error during encoding.
     open func encode<T: Encodable>(_ value: T,
                                    withRootKey rootKey: String? = nil,
-                                   rootAttributes: [String: String]? = nil,
+                                   rootAttributes: [(key: String, value: String)]? = nil,
                                    header: XMLHeader? = nil,
                                    doctype: XMLDocumentType? = nil) throws -> Data
     {

--- a/Tests/XMLCoderTests/RootLevetExtraAttributesTests.swift
+++ b/Tests/XMLCoderTests/RootLevetExtraAttributesTests.swift
@@ -13,9 +13,9 @@ final class RootLevetExtraAttributesTests: XCTestCase {
         let policy = Policy(name: "test", initial: "extra root attributes")
 
         let extraRootAttributes = [
-            "xmlns": "http://www.nrf-arts.org/IXRetail/namespace",
-            "xmlns:xsd": "http://www.w3.org/2001/XMLSchema",
-            "xmlns:xsi": "http://www.w3.org/2001/XMLSchema-instance",
+            ("xmlns", "http://www.nrf-arts.org/IXRetail/namespace"),
+            ("xmlns:xsd", "http://www.w3.org/2001/XMLSchema"),
+            ("xmlns:xsi", "http://www.w3.org/2001/XMLSchema-instance"),
         ]
 
         encoder.keyEncodingStrategy = .lowercased


### PR DESCRIPTION
This makes XML output deterministic and constant between consecutive encodings

Fixes  #297