### PR TITLE
Add support for XML stylesheet header

### DIFF
--- a/Sources/XMLCoder/Auxiliaries/XMLCoderElement.swift
+++ b/Sources/XMLCoder/Auxiliaries/XMLCoderElement.swift
@@ -147,7 +147,8 @@ struct XMLCoderElement: Equatable, Sendable {
     }
 
     func toXMLString(
-        with header: XMLHeader?,
+        header: XMLHeader?,
+        stylesheet: XMLStylesheet?,
         doctype: XMLDocumentType?,
         escapedCharacters: (elements: [(String, String)], attributes: [(String, String)]),
         formatting: XMLEncoder.OutputFormatting,
@@ -157,6 +158,10 @@ struct XMLCoderElement: Equatable, Sendable {
         
         if let header = header, let headerXML = header.toXML() {
             base += headerXML
+        }
+        
+        if let stylesheet = stylesheet, let stylesheetXML = stylesheet.toXML() {
+            base += stylesheetXML
         }
         
         if let doctype = doctype {

--- a/Sources/XMLCoder/Auxiliaries/XMLStylesheet.swift
+++ b/Sources/XMLCoder/Auxiliaries/XMLStylesheet.swift
@@ -1,0 +1,48 @@
+// Copyright (c) 2018-2026 XMLCoder contributors
+//
+// This software is released under the MIT License.
+// https://opensource.org/licenses/MIT
+//
+//  Created by Mateusz Jabłoński on 06/21/26.
+//
+
+import Foundation
+
+/// Type that allows overriding XML stylesheet during encoding. Pass a value of this type to the `encode`
+/// function of `XMLEncoder` to specify the exact value of the header you'd like to see in the encoded
+/// data.
+/// Specification: https://www.w3.org/TR/xml-stylesheet/
+public struct XMLStylesheet: Sendable {
+    /// Gives the address of the referenced style sheet.
+    public let href: String
+
+    /// Gives an advisory media type for the referenced style sheet.
+    public let type: String?
+
+    /// Gives the title of the referenced style sheet in a style sheet set.
+    public let  title : String?
+
+    public init(href: String, type: String? = nil, title: String? = nil) {
+        self.href = href
+        self.type = type
+        self.title = title
+    }
+
+    func toXML() -> String? {
+        var string = "<?xml-stylesheet"
+
+        string += " href=\"\(href)\""
+
+        if let type = type {
+            string += " type=\"\(type)\""
+        }
+
+        if let title = title {
+            string += " title=\"\(title)\""
+        }
+
+        string += "?>\n"
+
+        return string
+    }
+}

--- a/Sources/XMLCoder/Encoder/XMLEncoder.swift
+++ b/Sources/XMLCoder/Encoder/XMLEncoder.swift
@@ -360,7 +360,7 @@ open class XMLEncoder {
     /// - throws: An error if any value throws an error during encoding.
     open func encode<T: Encodable>(_ value: T,
                                    withRootKey rootKey: String? = nil,
-                                   rootAttributes: [String: String]? = nil,
+                                   rootAttributes: [(key: String, value: String)]? = nil,
                                    header: XMLHeader? = nil,
                                    doctype: XMLDocumentType? = nil) throws -> Data
     {

--- a/Sources/XMLCoder/Encoder/XMLEncoder.swift
+++ b/Sources/XMLCoder/Encoder/XMLEncoder.swift
@@ -362,6 +362,7 @@ open class XMLEncoder {
                                    withRootKey rootKey: String? = nil,
                                    rootAttributes: [(key: String, value: String)]? = nil,
                                    header: XMLHeader? = nil,
+                                   stylesheet: XMLStylesheet? = nil,
                                    doctype: XMLDocumentType? = nil) throws -> Data
     {
         let encoder = XMLEncoderImplementation(options: options, nodeEncodings: [])
@@ -409,7 +410,8 @@ open class XMLEncoder {
         }
 
         return element.toXMLString(
-            with: header,
+            header: header,
+            stylesheet: stylesheet,
             doctype: doctype,
             escapedCharacters: (
                 elements: charactersEscapedInElements,

--- a/Tests/XMLCoderTests/Auxiliary/XMLElementTests.swift
+++ b/Tests/XMLCoderTests/Auxiliary/XMLElementTests.swift
@@ -85,7 +85,8 @@ class XMLElementTests: XCTestCase {
                             attributes: [inputNamespace])
 
         let result = input.toXMLString(
-            with: nil,
+            header: nil,
+            stylesheet: nil,
             doctype: nil,
             escapedCharacters: (elements: XMLEncoder().charactersEscapedInElements,
                                 attributes: XMLEncoder().charactersEscapedInAttributes),
@@ -122,7 +123,8 @@ class XMLElementTests: XCTestCase {
                             attributes: [inputNamespace])
 
         let result = input.toXMLString(
-            with: nil,
+            header: nil,
+            stylesheet: nil,
             doctype: nil,
             escapedCharacters: (elements: XMLEncoder().charactersEscapedInElements,
                                 attributes: XMLEncoder().charactersEscapedInAttributes),

--- a/Tests/XMLCoderTests/RootLevetExtraAttributesTests.swift
+++ b/Tests/XMLCoderTests/RootLevetExtraAttributesTests.swift
@@ -13,9 +13,9 @@ final class RootLevetExtraAttributesTests: XCTestCase {
         let policy = Policy(name: "test", initial: "extra root attributes")
 
         let extraRootAttributes = [
-            "xmlns": "http://www.nrf-arts.org/IXRetail/namespace",
-            "xmlns:xsd": "http://www.w3.org/2001/XMLSchema",
-            "xmlns:xsi": "http://www.w3.org/2001/XMLSchema-instance",
+            ("xmlns", "http://www.nrf-arts.org/IXRetail/namespace"),
+            ("xmlns:xsd", "http://www.w3.org/2001/XMLSchema"),
+            ("xmlns:xsi", "http://www.w3.org/2001/XMLSchema-instance"),
         ]
 
         encoder.keyEncodingStrategy = .lowercased


### PR DESCRIPTION
This PR adds support for `xml-stylesheet` header https://www.w3.org/TR/xml-stylesheet/
Changes mimic existing `XMLHeader` approach.

Built on top of https://github.com/CoreOffice/XMLCoder/pull/300, so there are additional changes.